### PR TITLE
feat(dispatchOnMount): a decorator to manage subscriptions over the c…

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,8 @@
     "plugins": [
       "transform-function-bind",
       "transform-es2015-modules-commonjs",
-      "transform-object-rest-spread"
+      "transform-object-rest-spread",
+      "transform-decorators-legacy",
+      "transform-react-jsx"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -51,14 +51,17 @@
   "homepage": "https://github.com/blesh/rx-ducks-middleware#readme",
   "peerDependencies": {
     "redux": "3.*",
-    "rxjs": "^5.0.0-beta.6"
+    "rxjs": "^5.0.0-beta.6",
+    "react": "^14.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",
     "babel-eslint": "^6.0.3",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.7.4",
     "babel-plugin-transform-function-bind": "^6.5.2",
     "babel-plugin-transform-object-rest-spread": "^6.6.5",
+    "babel-plugin-transform-react-jsx": "^6.8.0",
     "babel-polyfill": "^6.7.4",
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.7.2",
@@ -66,6 +69,7 @@
     "eslint": "^2.10.2",
     "mocha": "^2.4.5",
     "promise": "^7.1.1",
+    "react": "^15.0.2",
     "redux": "^3.5.1",
     "rimraf": "^2.5.2",
     "rxjs": "^5.0.0-beta.6",

--- a/src/dispatchOnMount.js
+++ b/src/dispatchOnMount.js
@@ -1,0 +1,23 @@
+import { Component } from 'react';
+import { Subscription } from 'rxjs/Subscription';
+
+const $$reduxObservableSubscription = '@@reduxObservableSubscription';
+
+export function dispatchOnMount(...toDispatch) {
+  return (ComposedComponent) =>
+    class DispatchOnMountComponent extends Component {
+      componentDidMount() {
+        this[$$reduxObservableSubscription] = new Subscription();
+        toDispatch.map(a => this.context.store.dispatch(a))
+          .forEach(sub => sub && this[$$reduxObservableSubscription].add(sub));
+      }
+
+      componentWillUnmount() {
+        this[$$reduxObservableSubscription].unsubscribe();
+      }
+
+      render() {
+        return (<ComposedComponent {...this.props}/>);
+      }
+    };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
 export { reduxObservable } from './reduxObservable';
 export { ActionsObservable } from './ActionsObservable';
+export { dispatchOnMount } from './dispatchOnMount';

--- a/test/dispatchOnMount-spec.js
+++ b/test/dispatchOnMount-spec.js
@@ -1,0 +1,132 @@
+/* global describe, it */
+import { expect } from 'chai';
+import { dispatchOnMount, reduxObservable } from '../';
+import { Component } from 'react';
+import { createStore, applyMiddleware } from 'redux';
+import * as Rx from 'rxjs';
+import 'babel-polyfill';
+
+const { Observable } = Rx;
+
+describe('dispatchOnMount', () => {
+  it('should exist', () => {
+    expect(dispatchOnMount).to.be.a('function');
+  });
+
+  it('should wire a thunkservable to dispatch on componentDidMount', () => {
+    let reducedActions = [];
+    let reducer = (state, action) => {
+      reducedActions.push(action);
+      return state;
+    };
+    let store = createStore(reducer, applyMiddleware(reduxObservable()));
+
+    @dispatchOnMount(() => Observable.of({ type: 'TEST' }))
+    class TestComponent extends Component {
+    }
+
+    let comp = new TestComponent();
+    // fake connection?
+    comp.context = { store };
+    comp.componentDidMount();
+
+    expect(reducedActions).to.deep.equal([{ type: '@@redux/INIT' }, { type: 'TEST' }]);
+  });
+
+  it('should unsubscribe on componentWillUnmount', () => {
+    let reducedActions = [];
+    let reducer = (state, action) => {
+      reducedActions.push(action);
+      return state;
+    };
+    let store = createStore(reducer, applyMiddleware(reduxObservable()));
+
+    let source1Unsubbed = false;
+    let source1 = new Observable((observer) => {
+      return () => {
+        source1Unsubbed = true;
+      };
+    });
+
+    let source2Unsubbed = false;
+    let source2 = new Observable((observer) => {
+      return () => {
+        source2Unsubbed = true;
+      };
+    });
+
+    @dispatchOnMount(() => source1, () => source2)
+    class TestComponent extends Component {
+    }
+
+    let comp = new TestComponent();
+    // fake connection?
+    comp.context = { store };
+    comp.componentDidMount();
+
+    expect(source1Unsubbed).to.equal(false);
+    expect(source2Unsubbed).to.equal(false);
+
+    comp.componentWillUnmount();
+
+    expect(source1Unsubbed).to.equal(true);
+    expect(source2Unsubbed).to.equal(true);
+  });
+
+  it('should subscribe to multiple thunkservables', () => {
+    let reducedActions = [];
+    let reducer = (state, action) => {
+      reducedActions.push(action);
+      return state;
+    };
+    let store = createStore(reducer, applyMiddleware(reduxObservable()));
+
+    let source1 = Observable.of({ type: 'SOURCE1' });
+    let source2 = Observable.of({ type: 'SOURCE2' });
+
+    @dispatchOnMount(() => source1, () => source2)
+    class TestComponent extends Component {
+    }
+
+    let comp = new TestComponent();
+    // fake connection?
+    comp.context = { store };
+    comp.componentDidMount();
+
+    expect(reducedActions).to.deep.equal([
+      { type: '@@redux/INIT' },
+      { type: 'SOURCE1' },
+      { type: 'SOURCE2' }
+    ]);
+  });
+
+  it('should allow normal actions to dispatch on mount', () => {
+    let reducedActions = [];
+    let reducer = (state, action) => {
+      reducedActions.push(action);
+      return state;
+    };
+    let store = createStore(reducer, applyMiddleware(reduxObservable()));
+
+    let source2 = Observable.of({ type: 'SOURCE2' });
+
+    @dispatchOnMount({ type: 'PLAIN_ACTION' }, () => source2)
+    class TestComponent extends Component {
+    }
+
+    let comp = new TestComponent();
+    // fake connection?
+    comp.context = { store };
+    comp.componentDidMount();
+
+    expect(reducedActions).to.deep.equal([
+      { type: '@@redux/INIT' },
+      { type: 'PLAIN_ACTION' },
+      { type: 'SOURCE2' }
+    ]);
+
+    // since plain actions don't return subscriptions, because they're not functions
+    // let's just be really sure we don't break the unsub in the componentWillUnmount
+    expect(() => comp.componentWillUnmount()).not.to.throw();
+  });
+});


### PR DESCRIPTION
…omponent lifecycle

Adds a higher-order-component decorator that will dispatch multiple actions and thunkservables on componentDidMount, then manage any subscriptions that are returned by thunkservables and ensure they are disposed of when componentWillUnmount is called.

related #11