### PR TITLE
docs(examples): Add clickable `localhost` link

### DIFF
--- a/examples/basic/server.js
+++ b/examples/basic/server.js
@@ -12,5 +12,5 @@ new WebpackDevServer(webpack(config), {
     console.log(err);
   }
 
-  console.log('Listening at localhost:3000');
+  console.log('Listening at http://localhost:3000');
 });


### PR DESCRIPTION
I'm lazy and I want to be able to click a link in my terminal (iTerm 2) when I run an example. This makes it so I can do that.