### PR TITLE
feat(ofType): now accepts multiple types to filter for

### DIFF
--- a/src/ActionsObservable.js
+++ b/src/ActionsObservable.js
@@ -13,7 +13,19 @@ export class ActionsObservable extends Observable {
     return observable;
   }
 
-  ofType(key) {
-    return this::filter((action) => action.type === key);
+  ofType(...keys) {
+    return this::filter(({ type }) => {
+      const len = keys.length;
+      if (len === 1) {
+        return type === keys[0];
+      } else {
+        for (let i = 0; i < len; i++) {
+          if (keys[i] === type) {
+            return true;
+          }
+        }
+      }
+      return false;
+    });
   }
 }

--- a/test/ActionsObservable-spec.js
+++ b/test/ActionsObservable-spec.js
@@ -24,28 +24,55 @@ describe('ActionsObservable', () => {
     });
   });
 
-  it('should have a ofType operator that filters by action type', () => {
-    let actions = new Subject();
-    let actionsObs = new ActionsObservable(actions);
-    let lulz = [];
-    let haha = [];
+  describe('ofType operator', () => {
+    it('should filter by action type', () => {
+      let actions = new Subject();
+      let actionsObs = new ActionsObservable(actions);
+      let lulz = [];
+      let haha = [];
 
-    actionsObs.ofType('LULZ').subscribe(x => lulz.push(x));
-    actionsObs.ofType('HAHA').subscribe(x => haha.push(x));
+      actionsObs.ofType('LULZ').subscribe(x => lulz.push(x));
+      actionsObs.ofType('HAHA').subscribe(x => haha.push(x));
 
-    actions.next({ type: 'LULZ', i: 0 });
+      actions.next({ type: 'LULZ', i: 0 });
 
-    expect(lulz).to.deep.equal([{ type: 'LULZ', i: 0 }]);
-    expect(haha).to.deep.equal([]);
+      expect(lulz).to.deep.equal([{ type: 'LULZ', i: 0 }]);
+      expect(haha).to.deep.equal([]);
 
-    actions.next({ type: 'LULZ', i: 1 });
+      actions.next({ type: 'LULZ', i: 1 });
 
-    expect(lulz).to.deep.equal([{ type: 'LULZ', i: 0 }, { type: 'LULZ', i: 1 }]);
-    expect(haha).to.deep.equal([]);
+      expect(lulz).to.deep.equal([{ type: 'LULZ', i: 0 }, { type: 'LULZ', i: 1 }]);
+      expect(haha).to.deep.equal([]);
 
-    actions.next({ type: 'HAHA', i: 0 });
+      actions.next({ type: 'HAHA', i: 0 });
 
-    expect(lulz).to.deep.equal([{ type: 'LULZ', i: 0 }, { type: 'LULZ', i: 1 }]);
-    expect(haha).to.deep.equal([{ type: 'HAHA', i: 0 }]);
+      expect(lulz).to.deep.equal([{ type: 'LULZ', i: 0 }, { type: 'LULZ', i: 1 }]);
+      expect(haha).to.deep.equal([{ type: 'HAHA', i: 0 }]);
+    });
+
+    it('should filter by multiple action types', () => {
+      let actions = new Subject();
+      let actionsObs = new ActionsObservable(actions);
+      let lulz = [];
+      let haha = [];
+
+      actionsObs.ofType('LULZ', 'LARF').subscribe(x => lulz.push(x));
+      actionsObs.ofType('HAHA').subscribe(x => haha.push(x));
+
+      actions.next({ type: 'LULZ', i: 0 });
+
+      expect(lulz).to.deep.equal([{ type: 'LULZ', i: 0 }]);
+      expect(haha).to.deep.equal([]);
+
+      actions.next({ type: 'LARF', i: 1 });
+
+      expect(lulz).to.deep.equal([{ type: 'LULZ', i: 0 }, { type: 'LARF', i: 1 }]);
+      expect(haha).to.deep.equal([]);
+
+      actions.next({ type: 'HAHA', i: 0 });
+
+      expect(lulz).to.deep.equal([{ type: 'LULZ', i: 0 }, { type: 'LARF', i: 1 }]);
+      expect(haha).to.deep.equal([{ type: 'HAHA', i: 0 }]);
+    });
   });
 });


### PR DESCRIPTION
This adds a feature that allows to filter by multiple action types:

```
actions.ofType('ACTION_1', 'ACTION_2', 'ACTION_3')
```