### PR TITLE
Publish TypeScript definition files

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "typings": "./index.d.ts",
   "files": [
     "lib",
+    "index.d.ts",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
Hi there,

I noticed that `index.d.ts` is missing from the files inside the `package.json`. This causes some inconvenience when using TypeScript, because you can not just `import` the package. TypeScript won't find the module ...

As a workaround you can require it (when using webpack):

```ts
const reduxObservable = require('redux-observable').reduxObservable;
```

But types will still be missing.

When adding the `index.d.ts` to the installed package everything works fine :)
This patch adds the `index.d.ts` to the `files` property.

Thx for open sourcing this plugin ❤️ 

---
**tl;dr** Adding the `index.d.ts` to the `files` property of the `package.json` will make the module work with TypeScript better.