### PR TITLE
fix(typings): `ofType` accepts multie keys

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,5 +21,5 @@ export declare class ActionsObservable<T> extends Observable<T> {
   // property with a type signature of `any`
   // since `key` is being compared with an `Action`'s `type`, `key` has a type
   // signature of `any`
-  ofType(key: any);
+  ofType(...key: any[]);
 }


### PR DESCRIPTION
Since 9027d1c the `ofType` method allows to specify multiple action types for comparison.
Adjusted TypeScript typings accordingly.