### PR TITLE
Simplify dispatchToProps in example

### DIFF
--- a/examples/basic/src/components/Example.js
+++ b/examples/basic/src/components/Example.js
@@ -13,9 +13,9 @@ const Example = ({ user, fetchUser, abortFetchUser }) => (
 
 const mapStateToProps = ({ user }) => ({ user });
 
-const mapDispatchToProps = (dispatch) => ({
-  fetchUser: () => dispatch(fetchUser()),
-  abortFetchUser: () => dispatch(abortFetchUser())
-});
+const mapDispatchToProps = {
+  fetchUser,
+  abortFetchUser
+};
 
 export default connect(mapStateToProps, mapDispatchToProps)(Example);


### PR DESCRIPTION
Wrapping in dispatch is what the second argument to dispatch does if passed an object, no need to do it manually