### PR TITLE
npmcdn support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -251,6 +251,7 @@
   },
   "env": {
     "browser": true,
+    "node": true,
     "es6": true
   },
   "globals": {

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 lib
 temp
+dist

--- a/package.json
+++ b/package.json
@@ -5,12 +5,15 @@
   "main": "lib/index.js",
   "scripts": {
     "lint": "eslint src && eslint test",
-    "build": "npm run lint && rm -rf lib && babel src -d lib",
+    "build": "npm run build:commonjs && npm run build:umd && npm run build:umd:min",
+    "build:commonjs": "babel src -d lib",
+    "build:umd": "cross-env NODE_ENV=development webpack src/index.js dist/redux-observable.js",
+    "build:umd:min": "cross-env NODE_ENV=production webpack src/index.js dist/redux-observable.min.js",
     "build_tests": "rm -rf temp && babel test -d temp",
-    "clean": "rimraf ./lib; rimraf ./temp;",
+    "clean": "rimraf lib temp dist",
     "test": "npm run build && npm run build_tests && mocha temp && npm run test_typings",
     "test_typings": "tsc test/typings.ts --outFile temp/typings.js --target ES2015 --moduleResolution node",
-    "prepublish": "npm test"
+    "prepublish": "npm run clean && npm run lint && npm test"
   },
   "typings": "./index.d.ts",
   "files": [
@@ -57,6 +60,7 @@
   "devDependencies": {
     "babel-cli": "^6.7.5",
     "babel-eslint": "^6.0.3",
+    "babel-loader": "^6.2.4",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.7.4",
     "babel-plugin-transform-function-bind": "^6.5.2",
     "babel-plugin-transform-object-rest-spread": "^6.6.5",
@@ -64,6 +68,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.9.0",
     "chai": "^3.5.0",
+    "cross-env": "^1.0.8",
     "eslint": "^2.10.2",
     "json-server": "^0.8.14",
     "mocha": "^2.4.5",
@@ -72,6 +77,7 @@
     "rimraf": "^2.5.2",
     "rxjs": "^5.0.0-beta.6",
     "symbol-observable": "^0.2.4",
-    "typescript": "^1.8.10"
+    "typescript": "^1.8.10",
+    "webpack": "^1.13.1"
   }
 }

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -12,6 +12,19 @@ const config = {
     library: 'ReduxObservable',
     libraryTarget: 'umd'
   },
+  externals: {
+    'rxjs/Observable': 'Rx',
+    'rxjs/Subject': 'Rx',
+    'rxjs/observable/from': {
+      root: ['Rx', 'Observable', 'prototype'],
+    },
+    'rxjs/operator/filter': {
+      root: ['Rx', 'Observable', 'prototype']
+    },
+    'rxjs/observable/merge': {
+      root: ['Rx', 'Observable'],
+    },
+  },
   plugins: [
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.DefinePlugin({

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,0 +1,36 @@
+import webpack from 'webpack';
+
+const env = process.env.NODE_ENV;
+
+const config = {
+  module: {
+    loaders: [
+      { test: /\.js$/, loaders: ['babel-loader'], exclude: /node_modules/ }
+    ]
+  },
+  output: {
+    library: 'ReduxObservable',
+    libraryTarget: 'umd'
+  },
+  plugins: [
+    new webpack.optimize.OccurrenceOrderPlugin(),
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify(env)
+    })
+  ]
+};
+
+if (env === 'production') {
+  config.plugins.push(
+    new webpack.optimize.UglifyJsPlugin({
+      compressor: {
+        pure_getters: true,
+        unsafe: true,
+        unsafe_comps: true,
+        warnings: false
+      }
+    })
+  );
+}
+
+export default config;

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -15,7 +15,7 @@ const config = {
   },
   externals: {
     ...createRxJSExternals(),
-    'redux': {
+    redux: {
       root: 'Redux',
       commonjs2: 'redux',
       commonjs: 'redux',

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -16,7 +16,7 @@ const config = {
     'rxjs/Observable': 'Rx',
     'rxjs/Subject': 'Rx',
     'rxjs/observable/from': {
-      root: ['Rx', 'Observable', 'prototype'],
+      root: ['Rx', 'Observable'],
     },
     'rxjs/operator/filter': {
       root: ['Rx', 'Observable', 'prototype']


### PR DESCRIPTION
To avoid examples [like in this comment](https://github.com/redux-observable/redux-observable/issues/47#issuecomment-227593746) (sorry ;-))

Let's just publish redux-observable on [npmcdn](https://npmcdn.com)
All this project needs is umd versions at `dist` folder in npm.

So it will be avalable after `npm version patch; npm publish` at 
`https://npmcdn.com/redux-observable@latest/build/redux-observable.js`
`https://npmcdn.com/redux-observable@latest/build/redux-observable.min.js`

And can be accessed via global `ReduxObservable` var. At `jsbin` and similar playgrounds.