### PR TITLE
Thunk compatability concept

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
-import { Middleware } from 'redux';
-import { Observable } from 'rxjs/Observable';
+import { Middleware, Action, Store } from 'redux';
+import { Observable, ObservableInput } from 'rxjs/Observable';
 import { Operator } from 'rxjs/Operator';
+import { AnonymousSubscription } from 'rxjs/Subscription';
 
 export declare function reduxObservable(): Middleware;
 
@@ -22,4 +23,13 @@ export declare class ActionsObservable<T> extends Observable<T> {
   // since `key` is being compared with an `Action`'s `type`, `key` has a type
   // signature of `any`
   ofType(...key: any[]);
+}
+
+declare type ObservableThunk<S> = (actions: Observable<Action>, store: Store<S>) => ObservableInput<Action>; 
+
+declare module "redux" {
+  interface Dispatch<S> {
+    (observable: Observable<Action>): AnonymousSubscription;
+    (observableFn: { thunk: ObservableThunk<S>; }): AnonymousSubscription;
+  }
 }

--- a/src/reduxObservable.js
+++ b/src/reduxObservable.js
@@ -1,6 +1,7 @@
 import { Subject } from 'rxjs/Subject';
 import { from } from 'rxjs/observable/from';
 import { ActionsObservable } from './ActionsObservable';
+import $$observable from 'symbol-observable';
 
 export function reduxObservable(processor) {
   let actions = new Subject();
@@ -11,15 +12,21 @@ export function reduxObservable(processor) {
       processor(actionsObs, store).subscribe(store.dispatch);
     }
     return (action) => {
-      if (typeof action === 'function') {
-        let obs = from(action(actionsObs, store));
-        let sub = obs.subscribe(store.dispatch);
-        return sub;
-      } else {
-        let result = next(action);
-        actions.next(action);
-        return result;
+      if (action) {
+        if (typeof action.thunk === 'function') {
+          let obs = from(action.thunk(actionsObs, store));
+          let sub = obs.subscribe(store.dispatch);
+          return sub;
+        }
+        if (typeof action === 'function' && typeof action.subscribe === 'function' || action[$$observable]) {
+          let obs = from(action);
+          let sub = obs.subscribe(store.dispatch);
+          return sub;
+        }
       }
+      let result = next(action);
+      actions.next(action);
+      return result;
     };
   };
 

--- a/test/ActionsObservable-spec.js
+++ b/test/ActionsObservable-spec.js
@@ -18,10 +18,10 @@ describe('ActionsObservable', () => {
 
     let store = createStore(reducer, applyMiddleware(middleware));
 
-    store.dispatch((arg1) => {
+    store.dispatch({ thunk: (arg1) => {
       expect(arg1).to.be.an.instanceof(ActionsObservable);
       return of({ type: 'WEEE' });
-    });
+    } });
   });
 
   describe('ofType operator', () => {

--- a/test/reduxObservable-spec.js
+++ b/test/reduxObservable-spec.js
@@ -41,8 +41,8 @@ describe('reduxObservable', () => {
 
     const store = createStore(reducer, applyMiddleware(middleware));
 
-    store.dispatch(() => Observable.of({ type: 'ASYNC_ACTION_1' }).delay(10));
-    store.dispatch(() => Observable.of({ type: 'ASYNC_ACTION_2' }).delay(20));
+    store.dispatch(Observable.of({ type: 'ASYNC_ACTION_1' }).delay(10));
+    store.dispatch(Observable.of({ type: 'ASYNC_ACTION_2' }).delay(20));
 
     // HACKY: but should work until we use TestScheduler.
     setTimeout(() => {
@@ -62,8 +62,8 @@ describe('reduxObservable', () => {
 
     const store = createStore(reducer, applyMiddleware(middleware));
 
-    store.dispatch(() => Promise.resolve({ type: 'ASYNC_ACTION_1' }));
-    store.dispatch(() => Promise.resolve({ type: 'ASYNC_ACTION_2' }));
+    store.dispatch({ thunk: () => Promise.resolve({ type: 'ASYNC_ACTION_1' }) });
+    store.dispatch({ thunk: () => Promise.resolve({ type: 'ASYNC_ACTION_2' }) });
 
     // HACKY: but should work until we use TestScheduler.
     setTimeout(() => {
@@ -83,10 +83,10 @@ describe('reduxObservable', () => {
 
     const store = createStore(reducer, applyMiddleware(middleware));
 
-    store.dispatch(() => (function *() {
+    store.dispatch({ thunk: () => (function *() {
       yield { type: 'ASYNC_ACTION_1' };
       yield { type: 'ASYNC_ACTION_2' };
-    })());
+    })() });
 
     // HACKY: but should work until we use TestScheduler.
     setTimeout(() => {
@@ -108,7 +108,7 @@ describe('reduxObservable', () => {
 
     let finalized = false;
 
-    store.dispatch(() => ({
+    store.dispatch({
       [$$observable]() {
         return {
           subscribe(observer) {
@@ -124,7 +124,7 @@ describe('reduxObservable', () => {
           }
         };
       }
-    }));
+    });
 
     // HACKY: but should work until we use TestScheduler.
     setTimeout(() => {
@@ -146,7 +146,7 @@ describe('reduxObservable', () => {
 
     const store = createStore(reducer, applyMiddleware(middleware));
 
-    store.dispatch(
+    store.dispatch({ thunk:
       (actions) => Observable.of({ type: 'ASYNC_ACTION_2' })
         .delay(10)
         .takeUntil(actions.filter(action => action.type === 'ASYNC_ACTION_ABORT'))
@@ -156,7 +156,7 @@ describe('reduxObservable', () => {
             .take(1)
         )
         .startWith({ type: 'ASYNC_ACTION_1' })
-    );
+    });
 
     store.dispatch({ type: 'ASYNC_ACTION_ABORT' });
 
@@ -179,8 +179,8 @@ describe('reduxObservable', () => {
 
     const store = createStore(reducer, applyMiddleware(middleware));
 
-    const action2 = (actions) => Observable.of({ type: 'ASYNC_ACTION_2' });
-    const action1 = (actions) => Observable.of({ type: 'ASYNC_ACTION_1' }, action2);
+    const action2 = { thunk: (actions) => Observable.of({ type: 'ASYNC_ACTION_2' }) };
+    const action1 = { thunk: (actions) => Observable.of({ type: 'ASYNC_ACTION_1' }, action2) };
 
     store.dispatch(action1);
 


### PR DESCRIPTION
This PR is just a concept that addresses #13
I wanted to see how it could work and sharing with you.

**Rationale**
`redux-thunk` is extremely popular middleware for `redux`, so that there're numerous working samples and boilerplates/starters that use it. Since `redux-observable` is incompatible with it, people need to choose one.

**Changes**
1. added ability to dispatch an observable itself, without wrapping it to a factory function
2. changed the way how a function being passed; instead of passing the function, a plain object that has `thunk` field containing the function, must be used
3. _bonus_: added `redux` module augmentation with dispatch call signatures

So again, I didn't propose that change in #13, so that is kinda proposal and a call to discussion.