### PR TITLE
deprecate thunkservables and rename things to Epic

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ import { Middleware } from 'redux';
 import { Observable } from 'rxjs/Observable';
 import { Operator } from 'rxjs/Operator';
 
-export declare function reduxObservable(): Middleware;
+export declare function createEpicMiddleware(): Middleware;
 
 // ./node_modules/rxjs/Observable.d.ts
 export declare class ActionsObservable<T> extends Observable<T> {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:umd:min": "cross-env NODE_ENV=production webpack src/index.js dist/redux-observable.min.js",
     "build_tests": "rm -rf temp && babel test -d temp",
     "clean": "rimraf lib temp dist",
-    "test": "npm run build && npm run build_tests && mocha temp && npm run test_typings",
+    "test": "npm run lint && npm run build && npm run build_tests && mocha temp && npm run test_typings",
     "test_typings": "tsc test/typings.ts --outFile temp/typings.js --target ES2015 --moduleResolution node",
     "prepublish": "npm run clean && npm run lint && npm test"
   },
@@ -77,6 +77,7 @@
     "redux": "^3.5.1",
     "rimraf": "^2.5.2",
     "rxjs": "^5.0.0-beta.6",
+    "sinon": "1.17.4",
     "symbol-observable": "^0.2.4",
     "typescript": "^1.8.10",
     "webpack": "^1.13.1",

--- a/src/combineDelegators.js
+++ b/src/combineDelegators.js
@@ -1,7 +1,0 @@
-import { merge } from 'rxjs/observable/merge';
-
-/**
-  merges all delegators into a single delegator.
- */
-export const combineDelegators = (...delegators) => (actions, store) =>
-    merge(...(delegators.map((delegator) => delegator(actions, store))));

--- a/src/combineEpics.js
+++ b/src/combineEpics.js
@@ -1,0 +1,7 @@
+import { merge } from 'rxjs/observable/merge';
+
+/**
+  Merges all epics into a single one.
+ */
+export const combineEpics = (...epics) => (actions, store) =>
+  merge(...(epics.map(epic => epic(actions, store))));

--- a/src/createEpicMiddleware.js
+++ b/src/createEpicMiddleware.js
@@ -2,16 +2,20 @@ import { Subject } from 'rxjs/Subject';
 import { from } from 'rxjs/observable/from';
 import { ActionsObservable } from './ActionsObservable';
 
-export function reduxObservable(processor) {
+export function createEpicMiddleware(epic) {
   let actions = new Subject();
   let actionsObs = new ActionsObservable(actions);
 
   let middleware = (store) => (next) => {
-    if (processor) {
-      processor(actionsObs, store).subscribe(store.dispatch);
+    if (epic) {
+      epic(actionsObs, store).subscribe(store.dispatch);
     }
     return (action) => {
       if (typeof action === 'function') {
+        if (typeof console !== 'undefined' && typeof console.warn !== 'undefined') {
+          console.warn('DEPRECATION: Using thunkservables with redux-observable is now deprecated in favor of the new "Epics" feature. See https://github.com/redux-observable/redux-observable/blob/docs/docs/SUMMARY.md');
+        }
+
         let obs = from(action(actionsObs, store));
         let sub = obs.subscribe(store.dispatch);
         return sub;

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
-export { reduxObservable } from './reduxObservable';
+export { createEpicMiddleware } from './createEpicMiddleware';
 export { ActionsObservable } from './ActionsObservable';
-export { combineDelegators } from './combineDelegators';
+export { combineEpics } from './combineEpics';

--- a/test/ActionsObservable-spec.js
+++ b/test/ActionsObservable-spec.js
@@ -1,6 +1,6 @@
 /* globals describe it */
 import { expect } from 'chai';
-import { ActionsObservable, reduxObservable } from '../';
+import { ActionsObservable, createEpicMiddleware } from '../';
 import { createStore, applyMiddleware } from 'redux';
 import { of } from 'rxjs/observable/of';
 import { Subject } from 'rxjs/Subject';
@@ -11,7 +11,7 @@ describe('ActionsObservable', () => {
   });
 
   it('should be the type provided to a dispatched function', () => {
-    let middleware = reduxObservable();
+    let middleware = createEpicMiddleware();
     let reducer = (state, action) => {
       return state;
     };

--- a/test/combineEpics-spec.js
+++ b/test/combineEpics-spec.js
@@ -1,33 +1,33 @@
 /* globals describe it */
 import { expect } from 'chai';
-import { combineDelegators, ActionsObservable } from '../';
+import { combineEpics, ActionsObservable } from '../';
 import { Subject } from 'rxjs/Subject';
 import { map } from 'rxjs/operator/map';
 
-describe('combineDelegators', () => {
-  it('should combine delegators', () => {
-    let delegator1 = (actions, store) =>
+describe('combineEpics', () => {
+  it('should combine epics', () => {
+    let epic1 = (actions, store) =>
       actions.ofType('ACTION1')::map(action => ({ type: 'DELEGATED1', action, store }));
-    let delegator2 = (actions, store) =>
+    let epic2 = (actions, store) =>
       actions.ofType('ACTION2')::map(action => ({ type: 'DELEGATED2', action, store }));
 
-    let delegator = combineDelegators(
-      delegator1,
-      delegator2
+    let epic = combineEpics(
+      epic1,
+      epic2
     );
 
     let store = { I: 'am', a: 'store' };
     let subject = new Subject();
     let actions = new ActionsObservable(subject);
-    let result = delegator(actions, store);
-    let delegatedActions = [];
+    let result = epic(actions, store);
+    let emittedActions = [];
 
-    result.subscribe(delegatedAction => delegatedActions.push(delegatedAction));
+    result.subscribe(emittedAction => emittedActions.push(emittedAction));
 
     subject.next({ type: 'ACTION1' });
     subject.next({ type: 'ACTION2' });
 
-    expect(delegatedActions).to.deep.equal([
+    expect(emittedActions).to.deep.equal([
       { type: 'DELEGATED1', action: { type: 'ACTION1' }, store },
       { type: 'DELEGATED2', action: { type: 'ACTION2' }, store },
     ]);

--- a/test/typings.ts
+++ b/test/typings.ts
@@ -1,8 +1,8 @@
-import { reduxObservable, ActionsObservable } from '../index';
+import { createEpicMiddleware, ActionsObservable } from '../index';
 import { Observable } from 'rxjs/Observable';
 
 // should be a function
-reduxObservable();
+createEpicMiddleware();
 
 // should be a constructor that returns an observable
 const actionsSubject = Observable.create(() => {});


### PR DESCRIPTION
BREAKING CHANGE: We are deprecating thunkservables in favor of the new "epic"-style. Now, creating the middleware is done with `createEpicMiddleware(rootEpic)` instead of `reduxObservable(rootEpic)` and `combineDelegators()` has been renamed `combineEpics()`. See the brand new gitbook documentation (landing soon in #66) for more details on Epics.