### PR TITLE
feat(replaceEpic): Added middleware method to replace the root Epic.

### DIFF
--- a/docs/basics/Epics.md
+++ b/docs/basics/Epics.md
@@ -1,7 +1,7 @@
 # Epics
 
 >##### Not familiar with Observables/RxJS v5?
-> redux-observable requires an understanding of Observables with RS v5. If you're new to Reactive Programming with S v5, head over to [http://reactivex.io/rxjs/](http://reactivex.io/rxjs/) to familiarize yourself first.
+> redux-observable requires an understanding of Observables with RxJS v5. If you're new to Reactive Programming with RxJS v5, head over to [http://reactivex.io/rxjs/](http://reactivex.io/rxjs/) to familiarize yourself first.
 
 An **Epic** is the core primitive of redux-observable.
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "gitbook-cli": "^0.3.4",
     "json-server": "^0.8.14",
     "mocha": "^2.4.5",
-    "promise": "^7.1.1",
     "redux": "^3.5.1",
     "rimraf": "^2.5.2",
     "rxjs": "^5.0.0-beta.6",

--- a/src/EPIC_END.js
+++ b/src/EPIC_END.js
@@ -1,0 +1,1 @@
+export const EPIC_END = '@@redux-observable/EPIC_END';

--- a/src/createEpicMiddleware.js
+++ b/src/createEpicMiddleware.js
@@ -1,35 +1,44 @@
 import { Subject } from 'rxjs/Subject';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { from } from 'rxjs/observable/from';
+import { switchMap } from 'rxjs/operator/switchMap';
 import { ActionsObservable } from './ActionsObservable';
+import { EPIC_END } from './EPIC_END';
 
 export function createEpicMiddleware(epic) {
   const actionsSubject = new Subject();
   const action$ = new ActionsObservable(actionsSubject);
   const epic$ = new BehaviorSubject(epic);
+  let store;
 
-  const epicMiddleware = store => next => {
-    epic$.filter(epic => typeof epic === 'function')
-      .switchMap(epic => epic(action$, store))
-      .subscribe(store.dispatch);
+  const epicMiddleware = _store => {
+    store = _store;
 
-    return action => {
-      if (typeof action === 'function') {
-        if (typeof console !== 'undefined' && typeof console.warn !== 'undefined') {
-          console.warn('DEPRECATION: Using thunkservables with redux-observable is now deprecated in favor of the new "Epics" feature. See http://redux-observable.js.org/docs/FAQ.html#why-were-thunkservables-deprecated');
-        }
-
-        const out$ = from(action(action$, store));
-        return out$.subscribe(store.dispatch);
-      } else {
-        const result = next(action);
-        actionsSubject.next(action);
-        return result;
+    return next => {
+      if (typeof epic === 'function') {
+        epic$::switchMap(epic => epic(action$, store))
+          .subscribe(store.dispatch);
       }
+
+      return action => {
+        if (typeof action === 'function') {
+          if (typeof console !== 'undefined' && typeof console.warn !== 'undefined') {
+            console.warn('DEPRECATION: Using thunkservables with redux-observable is now deprecated in favor of the new "Epics" feature. See http://redux-observable.js.org/docs/FAQ.html#why-were-thunkservables-deprecated');
+          }
+
+          const out$ = from(action(action$, store));
+          return out$.subscribe(store.dispatch);
+        } else {
+          const result = next(action);
+          actionsSubject.next(action);
+          return result;
+        }
+      };
     };
   };
 
   epicMiddleware.replaceEpic = epic => {
+    store.dispatch({ type: EPIC_END });
     epic$.next(epic);
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 export { createEpicMiddleware } from './createEpicMiddleware';
 export { ActionsObservable } from './ActionsObservable';
 export { combineEpics } from './combineEpics';
+export { EPIC_END } from './EPIC_END';

--- a/test/typings.ts
+++ b/test/typings.ts
@@ -2,6 +2,8 @@ import { createEpicMiddleware, Epic, combineEpics,
   EpicMiddleware, ActionsObservable } from '../index';
 import { Action } from 'redux';
 import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/operator/mapTo';
 
 const epic1: Epic = (action$, store) =>
   action$.ofType('FIRST')
@@ -17,8 +19,19 @@ const epic2: Epic = (action$, store) =>
       payload: store.getState()
     });
 
-const rootEpic1: Epic = combineEpics(epic1, epic2);
-const rootEpic2: Epic = combineEpics(epic1, epic2);
+const epic3: Epic = action$ =>
+  action$.ofType('THIRD')
+    .mapTo({
+      type: 'third'
+    });
+
+const epic4: Epic = () =>
+  Observable.of({
+    type: 'third'
+  });
+
+const rootEpic1: Epic = combineEpics(epic1, epic2, epic3, epic4);
+const rootEpic2: Epic = combineEpics(epic1, epic2, epic3, epic4);
 
 const epicMiddleware: EpicMiddleware = createEpicMiddleware(rootEpic1);
 


### PR DESCRIPTION
**NOTE: I accidentally pushed an older version of [this to master days ago](https://github.com/redux-observable/redux-observable/commit/a8f458d1bf8db92c59a3e590869410e9ad73bf83) so #YOLO....part of this has already shipped. We can always revert, so it's not set in stone though.**

I'm still not convinced that using this is 100% safe, since Epics _may_ contain forms of state. There may be edge cases where losing that state causes the app to be in a bad state. For the most part that sort of state belongs in the store anyways, but this is likely not always obvious and there may be cases of ephemeral state that _should_ be in your Epic; after all, things like `Observable.ajax()` maintains internal state while the request is in-flight. Thinking we'll release it anyway and find out in practice whether it's an issue or not and then advise appropriately or rethink.

AFAICT redux-saga doesn't support Hot reloading either for basically the same reasons https://github.com/yelouafi/redux-saga/issues/22 Correct me if I'm wrong on this--the demos don't show it being used either, only for reducers.

Keep in mind that the old observables will all be unsubscribed, so you can use that opportunity to clean up any ephemeral state--things like `Observable.ajax()` will clean themselves up, cancelling in-flight AJAX requests. The `.finally()` operator is useful for this.

Closes #52, #53, #73

```js
import rootEpic from './where-ever-they-are';
const epicMiddleware = createEpicMiddleware(rootEpic);

if (module.hot) {
  module.hot.accept('./where-ever-they-are', () => {
    const rootEpic = require('./where-ever-the-are').default;
    epicMiddleware.replaceEpic(rootEpic);
  });
}
```