### PR TITLE
feat(Adapters): Adds support for Epic input/output adapters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## Install
 
 This has a peer dependencies of `rxjs@5.0.*` and `redux`, which will have to be installed
-as well. **It is not currently compatible with RxJS v4**
+as well. Support for RxJS v4 can temporarily be provided by [an optional adapter](https://github.com/redux-observable/redux-observable-adapter-rxjs-v4).
 
 ```sh
 npm install --save redux-observable

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -13,19 +13,17 @@
 ## General
 
 <a id="general-rxjs-v4"></a>
-### Does this work with RxJS 4/most.js/bacon.js? 
+### Does this work with RxJS 4/most.js/bacon.js/etc? 
 
 ##### RxJS v4
 
-Not out of box. We'd love to provide an elegant solution for this soon; ideally [RxJS v4 would add interop with `Symbol.observable`](https://github.com/Reactive-Extensions/RxJS/issues/1225).
+Not out of box, but we provide an adapter [redux-observable-adapter-rxjs-v4](https://github.com/redux-observable/redux-observable-adapter-rxjs-v4) you can install to add support temporarily while you transition to RxJS v5. Please upgrade to v5 as soon as possible as we do not plan to support this long-term.
 
 ##### most.js
-
-We believe so, but this is currently unconfirmed! (please let us know) [most.js supports interop](https://github.com/cujojs/most/blob/master/docs/api.md#draft-es-observable-interop) with the proposed ECMAScript Observable spec which RxJS builds on top of.
-
 ##### bacon.js
+##### etc.
 
-Not out of box. Some work has been done to make [bacon.js support](https://github.com/baconjs/bacon.js/issues/633) the `Symbol.observable` interop point.
+It should be possible for you to create an adapter to add support. See [redux-observable-adapter-rxjs-v4](https://github.com/redux-observable/redux-observable-adapter-rxjs-v4) for reference.
 
 <a id="miscellaneous-thunkservables-deprecated"></a>
 ### Why were thunkservables deprecated? 

--- a/test/createEpicMiddleware-spec.js
+++ b/test/createEpicMiddleware-spec.js
@@ -273,4 +273,24 @@ describe('createEpicMiddleware', () => {
       done();
     }, 100);
   });
+
+  it('supports an adapter for Epic input/output', () => {
+    const reducer = (state = [], action) => state.concat(action);
+    const epic = input => input + 1;
+
+    const adapter = {
+      input: () => 1,
+      output: value => of({
+        type: value + 1
+      })
+    };
+    const middleware = createEpicMiddleware(epic, { adapter });
+
+    const store = createStore(reducer, applyMiddleware(middleware));
+
+    expect(store.getState()).to.deep.equal([
+      { type: '@@redux/INIT' },
+      { type: 3 }
+    ]);
+  });
 });


### PR DESCRIPTION
This allows us to support RxJS v4 via https://github.com/redux-observable/redux-observable-adapter-rxjs-v4

An adapter is an object that has two properties, `input` and `output`.

```js
const adapter = {
  input: action$ => convertItSomeHow(action$),
  output: action$ => convertItSomeHow(action$)
};
```

The input function is provided the original v5 `ActionsObservable` and the result you return is then provided to all of your Epics.

The output function is invoked for each Epic, provided with the output of that Epic. The result you return is expected to be RxJS v5 compliant; anything that `Observable.from` works on so that includes `stream[Symbol.observable]()`.

We strongly believe people should switch to v5, but we realize that not everyone has the immediate cycles to do so, or have issues against software labeled as "beta"--though it's funny they would still use redux-observable (or similar middleware) which _is far more unstable than v5 is_.

Cc/ @blesh @BerkeleyTrue