### PR TITLE
feat(ActionsObservable.of): Added support for ActionsObservable.of(...actions)

### DIFF
--- a/src/ActionsObservable.js
+++ b/src/ActionsObservable.js
@@ -1,7 +1,12 @@
 import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 import { filter } from 'rxjs/operator/filter';
 
 export class ActionsObservable extends Observable {
+  static of(...actions) {
+    return new this(of(...actions));
+  }
+
   constructor(actionsSubject) {
     super();
     this.source = actionsSubject;

--- a/test/ActionsObservable-spec.js
+++ b/test/ActionsObservable-spec.js
@@ -10,6 +10,15 @@ describe('ActionsObservable', () => {
     expect(ActionsObservable).to.be.a('function');
   });
 
+  it('should support ActionsObservable.of(...actions)', () => {
+    const output = [];
+    const action$ = ActionsObservable.of({ type: 'FIRST', type: 'SECOND' });
+    action$.subscribe(x => output.push(x));
+
+    expect(action$).to.be.an.instanceof(ActionsObservable);
+    expect(output).to.deep.equal([{ type: 'FIRST', type: 'SECOND' }]);
+  });
+
   it('should be the type provided to a dispatched function', () => {
     let middleware = createEpicMiddleware();
     let reducer = (state, action) => {


### PR DESCRIPTION
Currently it's a little verbose to create a stream of actions, which happens a lot for testing but is also used in our experiments with "forking" short-lived instances of Epics.

##### Before
```js
const input$ = Observable.of(...actions);
const action$ = new ActionsObservable(input$);
```

##### After
```js
const action$ = ActionsObservable.of(...actions);
```

Closes #98