### PR TITLE
refactor(createEpicMiddleware): remove need to import/use BehaviorSubject

### DIFF
--- a/src/createEpicMiddleware.js
+++ b/src/createEpicMiddleware.js
@@ -1,5 +1,4 @@
 import { Subject } from 'rxjs/Subject';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { map } from 'rxjs/operator/map';
 import { switchMap } from 'rxjs/operator/switchMap';
 import { ActionsObservable } from './ActionsObservable';
@@ -23,7 +22,7 @@ export function createEpicMiddleware(epic, { adapter = defaultAdapter } = defaul
   const action$ = adapter.input(
     new ActionsObservable(input$)
   );
-  const epic$ = new BehaviorSubject(epic);
+  const epic$ = new Subject();
   let store;
 
   const epicMiddleware = _store => {
@@ -34,6 +33,9 @@ export function createEpicMiddleware(epic, { adapter = defaultAdapter } = defaul
         ::map(epic => epic(action$, store))
         ::switchMap(action$ => adapter.output(action$))
         .subscribe(store.dispatch);
+
+      // Setup initial root epic
+      epic$.next(epic);
 
       return action => {
         const result = next(action);


### PR DESCRIPTION
If you aren't familiar, a BehaviorSubject will "cache" the last value and emit it to anyone who subscribes any time after. This is unlike a regular Subject, which is just a simple hot stream--if you 'next()' something on it, only existing subscriptions receive it, not future ones.

In the case of createEpicMiddleware, using BehaviorSubject was just easier to read but came at the expense of depending on it, which I think we can do without.