### PR TITLE
fix(test): feed multiple actions through

### DIFF
--- a/test/ActionsObservable-spec.js
+++ b/test/ActionsObservable-spec.js
@@ -12,11 +12,11 @@ describe('ActionsObservable', () => {
 
   it('should support ActionsObservable.of(...actions)', () => {
     const output = [];
-    const action$ = ActionsObservable.of({ type: 'FIRST', type: 'SECOND' });
+    const action$ = ActionsObservable.of({ type: 'FIRST' }, { type: 'SECOND' });
     action$.subscribe(x => output.push(x));
 
     expect(action$).to.be.an.instanceof(ActionsObservable);
-    expect(output).to.deep.equal([{ type: 'FIRST', type: 'SECOND' }]);
+    expect(output).to.deep.equal([{ type: 'FIRST' }, { type: 'SECOND' }]);
   });
 
   it('should be the type provided to a dispatched function', () => {


### PR DESCRIPTION
I'm guessing this is what the test was intended for, to send multiple actions through and make sure they come out on the other side.