### PR TITLE
feat(combineEpics): combineEpics() now transparently passes along all arguments

### DIFF
--- a/src/combineEpics.js
+++ b/src/combineEpics.js
@@ -3,5 +3,7 @@ import { merge } from 'rxjs/observable/merge';
 /**
   Merges all epics into a single one.
  */
-export const combineEpics = (...epics) => (actions, store) =>
-  merge(...(epics.map(epic => epic(actions, store))));
+export const combineEpics = (...epics) => (...args) =>
+  merge(
+    ...epics.map(epic => epic(...args))
+  );

--- a/test/combineEpics-spec.js
+++ b/test/combineEpics-spec.js
@@ -1,5 +1,6 @@
 /* globals describe it */
 import { expect } from 'chai';
+import sinon from 'sinon';
 import { combineEpics, ActionsObservable } from '../';
 import { Subject } from 'rxjs/Subject';
 import { map } from 'rxjs/operator/map';
@@ -31,5 +32,23 @@ describe('combineEpics', () => {
       { type: 'DELEGATED1', action: { type: 'ACTION1' }, store },
       { type: 'DELEGATED2', action: { type: 'ACTION2' }, store },
     ]);
+  });
+
+  it('should pass along every argument arbitrarily', () => {
+    const epic1 = sinon.stub();
+    const epic2 = sinon.stub();
+
+    const rootEpic = combineEpics(
+      epic1,
+      epic2
+    );
+
+    rootEpic(1, 2, 3, 4);
+
+    expect(epic1.callCount).to.equal(1);
+    expect(epic2.callCount).to.equal(1);
+
+    expect(epic1.firstCall.args).to.deep.equal([1, 2, 3, 4]);
+    expect(epic2.firstCall.args).to.deep.equal([1, 2, 3, 4]);
   });
 });


### PR DESCRIPTION
which means now you can now easily inject dependencies to all your epics:

```js
// given epics like this
const epic1 = (action$, store, api) => {
  // access to API here!
};
```

```js
import * as api from './api/location';

// inject API into all epics as third arg
const rootEpic = (...args) => combineEpics(epic1, epic2)(...args, api);
```

which makes it easier to test:

```js
const fakeApi = {
  fetchSomething: () => Observable.of('fake response')
};
epic1(action$, fakeStore, fakeApi);
```

We may provide this functionality as an option to the middleware at some point since this composition may not be immediately obvious to people.

```js
// HYPOTHETICAL ONLY
createEpicMiddleware(rootEpic, { dependencies: [api] });
```