### PR TITLE
use @types (TS 2.0 feature) instead of the more complicated @typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "clean": "rimraf lib temp dist",
     "check": "npm run lint && npm run test",
     "test": "npm run lint && npm run build && npm run build:tests && mocha temp && npm run test:typings",
-    "test:typings": "typings install && tsc index.d.ts typings/index.d.ts test/typings.ts --outDir temp --target ES5 --moduleResolution node && cd temp && node typings.js",
+    "testd": "tsc -v",
+    "test:typings": "tsc index.d.ts test/typings.ts --outDir temp --target ES5 --moduleResolution node && cd temp && node typings.js",
     "shipit": "npm run clean && npm run build && npm run lint && npm test && scripts/preprepublish.sh && npm publish",
     "docs:clean": "rimraf _book",
     "docs:prepare": "gitbook install",
@@ -92,8 +93,11 @@
     "rxjs": "^5.0.0-beta.10",
     "sinon": "1.17.6",
     "typescript": "^2.0.3",
-    "typings": "1.4.0",
     "webpack": "^1.13.1",
     "webpack-rxjs-externals": "~0.0.3"
+  },
+  "dependencies": {
+    "@types/chai": "3.4.33",
+    "@types/es6-shim": "0.31.32"
   }
 }

--- a/typings.json
+++ b/typings.json
@@ -1,6 +1,0 @@
-{
-  "globalDependencies": {
-    "chai": "registry:dt/chai#3.4.0+20160601211834",
-    "es6-shim": "registry:dt/es6-shim#0.31.2+20160602141504"
-  }
-}


### PR DESCRIPTION
**In theory, this should not impact anyone _consuming_ redux-observable. You can still use pre-2.0 TypeScript. If you have trouble, let us know. This is just internal stuff for us maintainers**

Now that we're on TypeScript 2.0 we can use their new @types system for external type definitions [described here](https://blogs.msdn.microsoft.com/typescript/2016/09/22/announcing-typescript-2-0/). Much easier. The external type def ecosystem is complicated (types, typings, DefinitelyTyped, etc) so if you have concerns about this impacting anyone let me know!

We're going to keep the `--strictNullChecks` flag _off_ for now, until the community starts adopting it more so we maintain backwards compatibility. (there may be a way to support both, I just don't know yet)
