### PR TITLE
fix(UMD build): now properly sets up external requires statements

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "sinon": "1.17.6",
     "typescript": "^2.0.3",
     "typings": "1.4.0",
-    "webpack": "^1.13.1",
-    "webpack-rxjs-externals": "~0.0.3"
+    "webpack": "^2.1.0-beta.25"
   }
 }

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,9 +1,30 @@
 import webpack from 'webpack';
-import createRxJSExternals from 'webpack-rxjs-externals';
 
 const env = process.env.NODE_ENV;
 
+const rxRoot = {
+  root: 'Rx',
+  commonjs: 'Rx',
+  commonjs2: 'Rx',
+  amd: 'Rx'
+};
+
+const rxOperators = {
+  root: ['Rx', 'Observable', 'prototype'],
+  commonjs: ['Rx', 'Observable', 'prototype'],
+  commonjs2: ['Rx', 'Observable', 'prototype'],
+  amd: ['Rx', 'Observable', 'prototype']
+};
+
+const rxStatic = {
+  root: ['Rx', 'Observable'],
+  commonjs: ['Rx', 'Observable'],
+  commonjs2: ['Rx', 'Observable'],
+  amd: ['Rx', 'Observable']
+};
+
 const config = {
+  bail: true,
   module: {
     loaders: [
       { test: /\.js$/, loaders: ['babel-loader'], exclude: /node_modules/ }
@@ -14,7 +35,18 @@ const config = {
     libraryTarget: 'umd'
   },
   externals: {
-    ...createRxJSExternals(),
+    'rxjs/Observable': rxRoot,
+    'rxjs/Subject': rxRoot,
+    'rxjs/Operator': rxRoot,
+    'rxjs/operator/map': rxOperators,
+    'rxjs/operator/mapTo': rxOperators,
+    'rxjs/operator/filter': rxOperators,
+    'rxjs/operator/merge': rxOperators,
+    'rxjs/operator/switchMap': rxOperators,
+    'rxjs/operator/toArray': rxOperators,
+    'rxjs/observable/of': rxStatic,
+    'rxjs/observable/merge': rxStatic,
+    'rxjs/observable/empty': rxStatic,
     redux: {
       root: 'Redux',
       commonjs2: 'redux',


### PR DESCRIPTION
After speaking with @TheLarkInn, it seemed that what was coming from `webpack-rxjs-externals` was incomplete. This PR removes that dependency and adds the stuff we're using specifically.

fixes #126