### PR TITLE
fix(UMD): bump webpack-rxjs-externals to correct UMD generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,6 @@
     "typescript": "^2.0.3",
     "typings": "1.4.0",
     "webpack": "^1.13.1",
-    "webpack-rxjs-externals": "~0.0.3"
+    "webpack-rxjs-externals": "~0.0.4"
   }
 }


### PR DESCRIPTION
fixes #127

Upstream webpack-rxjs-externals change: https://github.com/jayphelps/webpack-rxjs-externals/pull/1

Cc/ @blesh 


(it was already matching under our semver range, but bumping to reduce likelyhood of local caching of incorrect older lib and have a clear trace back to the fix)