### PR TITLE
chore(examples & docs): Change deprecated Redux DevTools extension enhancer

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -70,10 +70,6 @@ const myEpic = action$ => { // MISSING EXPLICIT RETURN!
 };
 ```
 
-### Actions dispatched from Redux DevTools do not reach Epics
-
-This is caused by a current limitation of Redux, but [there is a workaround available](basics/SettingUpTheMiddleware.md#redux-devtools).
-
 ### this is set to Window
 
 If you are organizing your epics into a class. (E.g. in order to benefit from Angular 2 dependency injection), you might have made the mistake of using class methods:

--- a/docs/basics/SettingUpTheMiddleware.md
+++ b/docs/basics/SettingUpTheMiddleware.md
@@ -30,7 +30,7 @@ export const rootReducer = combineReducers({
 
 ## Configuring The Store
 
-Now you'll want to create an instance of the redux-observable middleware, passing along our newly created root Epic. 
+Now you'll want to create an instance of the redux-observable middleware, passing along our newly created root Epic.
 
 ```js
 import { createEpicMiddleware } from 'redux-observable';
@@ -63,20 +63,16 @@ export default function configureStore() {
 
 ## Redux DevTools
 
-If you're using the Redux DevTools Extension, you'll need to invoke `window.devToolsExtension.updateStore(store)`, otherwise your Epics will not receive any actions you dispatch using the DevTools UI.
+To enable Redux DevTools Extension, just use `window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__` or [import `redux-devtools-extension` npm package](https://github.com/zalmoxisus/redux-devtools-extension#13-use-redux-devtools-extension-package-from-npm).
 
 ```js
 const epicMiddleware = createEpicMiddleware(pingEpic);
 
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+
 const store = createStore(pingReducer,
-  compose(
-    applyMiddleware(epicMiddleware),
-    window.devToolsExtension ? window.devToolsExtension() : f => f
+  composeEnhancers(
+    applyMiddleware(epicMiddleware)
   )
 );
-
-if (window.devToolsExtension) {
-  window.devToolsExtension.updateStore(store);
-}
 ```
-This is required to get around a limitation of Redux, but is [planned to be fixed soon](https://github.com/reactjs/redux/pull/1702).

--- a/examples/navigation/configureStore.js
+++ b/examples/navigation/configureStore.js
@@ -8,14 +8,14 @@ import rootEpic from './epics';
 const epicMiddleware = createEpicMiddleware(rootEpic);
 
 export default function configureStore() {
+  const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
   const store = createStore(
     rootReducer,
-    compose(
+    composeEnhancers(
       applyMiddleware(
         epicMiddleware,
         routerMiddleware(browserHistory)
-      ),
-      window.devToolsExtension ? window.devToolsExtension() : f => f
+      )
     )
   );
   return store;


### PR DESCRIPTION
The extension API was changed and [`window.devToolsExtension` is being deprecated](https://github.com/zalmoxisus/redux-devtools-extension/issues/220). No need for `window.devToolsExtension.updateStore` workaround anymore.

Fixes #81.