### PR TITLE
refactor(rxjs): no longer use function-bind syntax

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,6 @@
 {
     "presets": ["es2015"],
     "plugins": [
-      "transform-function-bind",
       "transform-es2015-modules-commonjs",
       "transform-object-rest-spread"
     ]

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "babel-eslint": "^7.0.0",
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.11.5",
-    "babel-plugin-transform-function-bind": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-polyfill": "^6.13.0",
     "babel-preset-es2015": "^6.13.2",

--- a/src/ActionsObservable.js
+++ b/src/ActionsObservable.js
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs/Observable';
 import { of } from 'rxjs/observable/of';
-import { filter } from 'rxjs/operator/filter';
+import { $$filter } from './operators';
 
 export class ActionsObservable extends Observable {
   static of(...actions) {
@@ -19,7 +19,7 @@ export class ActionsObservable extends Observable {
   }
 
   ofType(...keys) {
-    return this::filter(({ type }) => {
+    return this[$$filter](({ type }) => {
       const len = keys.length;
       if (len === 1) {
         return type === keys[0];

--- a/src/createEpicMiddleware.js
+++ b/src/createEpicMiddleware.js
@@ -1,6 +1,5 @@
 import { Subject } from 'rxjs/Subject';
-import { map } from 'rxjs/operator/map';
-import { switchMap } from 'rxjs/operator/switchMap';
+import { $$map, $$switchMap } from './operators';
 import { ActionsObservable } from './ActionsObservable';
 import { EPIC_END } from './EPIC_END';
 
@@ -30,8 +29,8 @@ export function createEpicMiddleware(epic, { adapter = defaultAdapter } = defaul
 
     return next => {
       epic$
-        ::map(epic => epic(action$, store))
-        ::switchMap(action$ => adapter.output(action$))
+        [$$map](epic => epic(action$, store))
+        [$$switchMap](action$ => adapter.output(action$))
         .subscribe(store.dispatch);
 
       // Setup initial root epic

--- a/src/operators.js
+++ b/src/operators.js
@@ -1,0 +1,12 @@
+import { Observable } from 'rxjs/Observable';
+import { filter } from 'rxjs/operator/filter';
+import { map } from 'rxjs/operator/map';
+import { switchMap } from 'rxjs/operator/switchMap';
+
+export const $$filter = Symbol('@@filter');
+export const $$map = Symbol('@@map');
+export const $$switchMap = Symbol('@@switchMap');
+
+Observable.prototype[$$filter] = filter;
+Observable.prototype[$$map] = map;
+Observable.prototype[$$switchMap] = switchMap;

--- a/test/combineEpics-spec.js
+++ b/test/combineEpics-spec.js
@@ -9,9 +9,9 @@ import { toArray } from 'rxjs/operator/toArray';
 describe('combineEpics', () => {
   it('should combine epics', () => {
     let epic1 = (actions, store) =>
-      actions.ofType('ACTION1')::map(action => ({ type: 'DELEGATED1', action, store }));
+      map.call(actions.ofType('ACTION1'), action => ({ type: 'DELEGATED1', action, store }));
     let epic2 = (actions, store) =>
-      actions.ofType('ACTION2')::map(action => ({ type: 'DELEGATED2', action, store }));
+      map.call(actions.ofType('ACTION2'), action => ({ type: 'DELEGATED2', action, store }));
 
     let epic = combineEpics(
       epic1,
@@ -44,7 +44,7 @@ describe('combineEpics', () => {
       epic2
     );
 
-    rootEpic(1, 2, 3, 4)::toArray().subscribe(values => {
+    toArray.call(rootEpic(1, 2, 3, 4)).subscribe(values => {
       expect(values).to.deep.equal(['first', 'second']);
 
       expect(epic1.callCount).to.equal(1);

--- a/test/createEpicMiddleware-spec.js
+++ b/test/createEpicMiddleware-spec.js
@@ -29,8 +29,8 @@ describe('createEpicMiddleware', () => {
     const reducer = (state = [], action) => state.concat(action);
     const epic = (action$, store) =>
       mergeStatic(
-        action$.ofType('FIRE_1')::mapTo({ type: 'ACTION_1' }),
-        action$.ofType('FIRE_2')::mapTo({ type: 'ACTION_2' })
+        mapTo.call(action$.ofType('FIRE_1'), { type: 'ACTION_1' }),
+        mapTo.call(action$.ofType('FIRE_2'), { type: 'ACTION_2' })
       );
 
     const middleware = createEpicMiddleware(epic);
@@ -54,17 +54,17 @@ describe('createEpicMiddleware', () => {
     const epic1 = action$ =>
       mergeStatic(
         of({ type: 'EPIC_1' }),
-        action$.ofType('FIRE_1')::mapTo({ type: 'ACTION_1' }),
-        action$.ofType('FIRE_2')::mapTo({ type: 'ACTION_2' }),
-        action$.ofType('FIRE_GENERIC')::mapTo({ type: 'EPIC_1_GENERIC' }),
-        action$.ofType(EPIC_END)::mapTo({ type: 'CLEAN_UP_AISLE_3' })
+        mapTo.call(action$.ofType('FIRE_1'), { type: 'ACTION_1' }),
+        mapTo.call(action$.ofType('FIRE_2'), { type: 'ACTION_2' }),
+        mapTo.call(action$.ofType('FIRE_GENERIC'), { type: 'EPIC_1_GENERIC' }),
+        mapTo.call(action$.ofType(EPIC_END), { type: 'CLEAN_UP_AISLE_3' })
       );
     const epic2 = action$ =>
       mergeStatic(
         of({ type: 'EPIC_2' }),
-        action$.ofType('FIRE_3')::mapTo({ type: 'ACTION_3' }),
-        action$.ofType('FIRE_4')::mapTo({ type: 'ACTION_4' }),
-        action$.ofType('FIRE_GENERIC')::mapTo({ type: 'EPIC_2_GENERIC' })
+        mapTo.call(action$.ofType('FIRE_3'), { type: 'ACTION_3' }),
+        mapTo.call(action$.ofType('FIRE_4'), { type: 'ACTION_4' }),
+        mapTo.call(action$.ofType('FIRE_GENERIC'), { type: 'EPIC_2_GENERIC' })
       );
 
     const middleware = createEpicMiddleware(epic1);


### PR DESCRIPTION
This is an internal detail, users should not be affected.

No longer use function-bind syntax, use private Symbols for Observable operators we use internally. We don't want to continue depending on a stage-0 syntax. The reason we did was we don't want to decorate the `Observable.prototype` with operators because then users of redux-observable can then accidentally depend on the fact that a operator we need internally exists on that prototype. So if we no longer use it, that fact could cause users apps to break because they aren't importing the operator as well.

With the private Symbols approach, we add the operators we need for internal use but since they're Symbols that are not public, it's not possible for users to accidentally depend on them.

Neither of these approaches will be necessary in the future if RxJS gets something like: https://github.com/ReactiveX/rxjs/pull/2034
