### PR TITLE
docs(SettingUpTheMiddleware): Clarify arguments

### DIFF
--- a/docs/basics/SettingUpTheMiddleware.md
+++ b/docs/basics/SettingUpTheMiddleware.md
@@ -6,7 +6,7 @@ Now that we know what [Epics](Epics.md) are, we need to provide them to the redu
 
 Just like redux requiring a single root Reducer, redux-observable also requires you to have a single root Epic. As we [learned previously](Epics.md), we can use `combineEpics()` to accomplish this.
 
-One common pattern is to import all your Epics into a single file, which then exports the root Epic, along with your root Reducer.
+One common pattern is to import all your Epics into a single file, which then exports the root Epic, along with your root Reducer. Note that `combineEpics` takes comma-separated arguments instead of an object like `combineReducers`.
 
 ### redux/modules/root.js
 


### PR DESCRIPTION
<!-- If this is your first PR for redux-observable, please mark these boxes to confirm (otherwise you can exclude them)-->

Just set up my rootEpic and stumbled a little bit here. There is a subtle but important difference between the `combineEpics` and `combineReducers` signatures.
- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.
