### PR TITLE
chore(errors): detect epics which do not return anything

### DIFF
--- a/src/combineEpics.js
+++ b/src/combineEpics.js
@@ -5,5 +5,11 @@ import { merge } from 'rxjs/observable/merge';
  */
 export const combineEpics = (...epics) => (...args) =>
   merge(
-    ...epics.map(epic => epic(...args))
+    ...epics.map(epic => {
+      const output$ = epic(...args);
+      if (!output$) {
+        throw new TypeError(`combineEpics: one of the provided Epics "${epic.name || '<anonymous>'}" does not return a stream. Double check you\'re not missing a return statement!`);
+      }
+      return output$;
+    })
   );

--- a/test/combineEpics-spec.js
+++ b/test/combineEpics-spec.js
@@ -8,21 +8,21 @@ import { toArray } from 'rxjs/operator/toArray';
 
 describe('combineEpics', () => {
   it('should combine epics', () => {
-    let epic1 = (actions, store) =>
+    const epic1 = (actions, store) =>
       actions.ofType('ACTION1')::map(action => ({ type: 'DELEGATED1', action, store }));
-    let epic2 = (actions, store) =>
+    const epic2 = (actions, store) =>
       actions.ofType('ACTION2')::map(action => ({ type: 'DELEGATED2', action, store }));
 
-    let epic = combineEpics(
+    const epic = combineEpics(
       epic1,
       epic2
     );
 
-    let store = { I: 'am', a: 'store' };
-    let subject = new Subject();
-    let actions = new ActionsObservable(subject);
-    let result = epic(actions, store);
-    let emittedActions = [];
+    const store = { I: 'am', a: 'store' };
+    const subject = new Subject();
+    const actions = new ActionsObservable(subject);
+    const result = epic(actions, store);
+    const emittedActions = [];
 
     result.subscribe(emittedAction => emittedActions.push(emittedAction));
 
@@ -55,5 +55,15 @@ describe('combineEpics', () => {
 
       done();
     });
+  });
+
+  it('should return a new epic that, when called, errors if one of the combined epics doesn\'t return anything', () => {
+    const epic1 = () => [];
+    const epic2 = () => {};
+    const rootEpic = combineEpics(epic1, epic2);
+
+    expect(() => {
+      rootEpic();
+    }).to.throw('combineEpics: one of the provided Epics "epic2" does not return a stream. Double check you\'re not missing a return statement!');
   });
 });

--- a/test/createEpicMiddleware-spec.js
+++ b/test/createEpicMiddleware-spec.js
@@ -34,7 +34,6 @@ describe('createEpicMiddleware', () => {
       );
 
     const middleware = createEpicMiddleware(epic);
-
     const store = createStore(reducer, applyMiddleware(middleware));
 
     store.dispatch({ type: 'FIRE_1' });
@@ -47,6 +46,25 @@ describe('createEpicMiddleware', () => {
       { type: 'FIRE_2' },
       { type: 'ACTION_2' }
     ]);
+  });
+
+  it('should throw if you don\'t provide a rootEpic', () => {
+    expect(() => {
+      createEpicMiddleware();
+    }).to.throw('You must provide a root Epic to createEpicMiddleware');
+
+    expect(() => {
+      createEpicMiddleware({});
+    }).to.throw('You must provide a root Epic to createEpicMiddleware');
+  });
+
+  it('should throw if you provide a root epic that doesn\'t return anything', () => {
+    const rootEpic = () => {};
+    const epicMiddleware = createEpicMiddleware(rootEpic);
+
+    expect(() => {
+      createStore(() => {}, applyMiddleware(epicMiddleware));
+    }).to.throw('Your root Epic "rootEpic" does not return a stream. Double check you\'re not missing a return statement!');
   });
 
   it('should allow you to replace the root epic with middleware.replaceEpic(epic)', () => {


### PR DESCRIPTION
Provides a more descriptive error when someone accidentally doesn't return something from their epics

```js
const someEpic = () => {
  action$.ofType(SOMETHING).etc(); // whoops! forgot to return the stream!
};
```

Someone may ask why we don't try and check whether what they returned is an Observable e.g. `output instanceof Observable`. The reason is that we support any stream-like thing that RxJS supports, which is Observable, an array, an iterable/generator, or object which has `Symbol.observable` property. [see here](https://github.com/ReactiveX/rxjs/blob/master/src/util/subscribeToResult.ts). I think checking for this exhaustive list is excessive, because RxJS itself will check and error too (assuming it's not undefined, which is what we're protecting against now)

I'll try and update RxJS to also provide a more descriptive error when passed `undefined`, but since this happens seemingly often enough we'll still keep this check in redux-observable too. Right now RxJS assumes it's at least an object, so it errors out when it reaches the iterable check `Cannot read property 'Symbol(Symbol.iterator)' of undefined`