### PR TITLE
feat(ActionsObservable): Support for .ofType(predicate)

### DIFF
--- a/src/ActionsObservable.js
+++ b/src/ActionsObservable.js
@@ -24,9 +24,13 @@ export class ActionsObservable extends Observable {
   }
 
   ofType(...keys) {
-    return this::filter(({ type }) => {
+    return this::filter((action) => {
+      const { type } = action;
       const len = keys.length;
       if (len === 1) {
+        if (typeof keys[0] === 'function') {
+          return keys[0](action);
+        }
         return type === keys[0];
       } else {
         for (let i = 0; i < len; i++) {


### PR DESCRIPTION
<!-- If this is your first PR for redux-observable, please mark these boxes to confirm (otherwise you can exclude them)-->

- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.

As heavy `redux-saga` user and collaborator I've found this pattern really useful in making some generic sagas, not focused on exact `type` for example. String comparison is sometimes just not enough. 

Im happy to fix PR if you have some stylistic suggestions (or any other too!). 

If you accept the change, I'm gonna write tests and docs and include them in the PR via amend. 

Also I guess most of the use cases (but not all of them) can be easily accomplished with `filter` in userland, but even for those its nice (I think) to have this behaviour builtin.