### PR TITLE
fix(typings): Enable second parameter for the createEpicMiddleware

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,6 +35,15 @@ export interface EpicMiddleware<T> extends Middleware {
   replaceEpic(nextEpic: Epic<T>): void;
 }
 
-export declare function createEpicMiddleware<T>(rootEpic: Epic<T>): EpicMiddleware<T>;
+interface Adapter { 
+  input: (input$: Observable<any>) => any;
+  output: (output$: any) => Observable<any>;
+}
+
+interface Options {
+  adapter?: Adapter;
+}
+
+export declare function createEpicMiddleware<T>(rootEpic: Epic<T>, options?: Options): EpicMiddleware<T>;
 
 export declare function combineEpics<T>(...epics: Epic<T>[]): Epic<T>;


### PR DESCRIPTION
<!-- If this is your first PR for redux-observable, please mark these boxes to confirm (otherwise you can exclude them)-->

- [X ] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [X ] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.

When using TypeScript, you will be able to use any adapter
without TypeScript compiler complaining about wrong signature of call target.