### PR TITLE
Documentation: added the missing import for 'combineReducers'

### DIFF
--- a/docs/basics/SettingUpTheMiddleware.md
+++ b/docs/basics/SettingUpTheMiddleware.md
@@ -12,6 +12,7 @@ One common pattern is to import all your Epics into a single file, which then ex
 
 ```js
 import { combineEpics } from 'redux-observable';
+import { combineReducers } from 'redux';
 import ping, { pingEpic } from './ping';
 import users, { fetchUserEpic } from './users';
 


### PR DESCRIPTION
A trivial change in the documentation - an import was missing.

- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.
