### PR TITLE
docs(navigation-example): request via nextProps

### DIFF
--- a/examples/navigation/containers/ReposByUser.jsx
+++ b/examples/navigation/containers/ReposByUser.jsx
@@ -8,13 +8,6 @@ class ReposByUser extends React.Component {
     this.props.requestReposByUser(this.props.params.user);
   }
 
-  componentWillReceiveProps(nextProps) {
-    const { user } = this.props.params;
-    if (user !== nextProps.params.user) {
-      this.props.requestReposByUser(user);
-    }
-  }
-
   render() {
     const {
       reposByUser,


### PR DESCRIPTION
@gusvargas - was this meant to do a query based on the `user` from the `nextProps` if the old props didn't match?