### PR TITLE
fix(typescript): adds store type to Epic

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,16 +23,16 @@ export declare class ActionsObservable<T> extends Observable<T> {
   static from<T, R>(ish: ArrayLike<T>, scheduler?: Scheduler): ActionsObservable<R>;
 
   constructor(input$: Observable<T>);
-  lift(operator: Operator<any, T>) : ActionsObservable<T>;
-  ofType(...key: any[]) : ActionsObservable<T>;
+  lift(operator: Operator<any, T>): ActionsObservable<T>;
+  ofType(...key: any[]): ActionsObservable<T>;
 }
 
-export declare interface Epic<T> {
-  (action$: ActionsObservable<T>, store: MiddlewareAPI<any>): Observable<T>;
+export declare interface Epic<T, S> {
+  (action$: ActionsObservable<T>, store: MiddlewareAPI<S>): Observable<T>;
 }
 
-export interface EpicMiddleware<T> extends Middleware {
-  replaceEpic(nextEpic: Epic<T>): void;
+export interface EpicMiddleware<T, S> extends Middleware {
+  replaceEpic(nextEpic: Epic<T, S>): void;
 }
 
 interface Adapter { 
@@ -44,6 +44,6 @@ interface Options {
   adapter?: Adapter;
 }
 
-export declare function createEpicMiddleware<T>(rootEpic: Epic<T>, options?: Options): EpicMiddleware<T>;
+export declare function createEpicMiddleware<T, S>(rootEpic: Epic<T, S>, options?: Options): EpicMiddleware<T, S>;
 
-export declare function combineEpics<T>(...epics: Epic<T>[]): Epic<T>;
+export declare function combineEpics<T, S>(...epics: Epic<T, S>[]): Epic<T, S>;

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "@types/chai": "^3.4.34",
     "@types/es6-shim": "^0.31.32",
     "@types/mocha": "^2.2.33",
-    "@types/redux": "^3.6.0",
     "@types/sinon": "^1.16.32",
     "babel-cli": "^6.11.4",
     "babel-eslint": "^7.0.0",

--- a/test/typings.ts
+++ b/test/typings.ts
@@ -17,30 +17,30 @@ interface FluxStandardAction {
   meta?: any
 }
 
-const epic1: Epic<FluxStandardAction> = (action$: ActionsObservable<FluxStandardAction>, store) =>
+const epic1: Epic<FluxStandardAction, any> = (action$: ActionsObservable<FluxStandardAction>, store) =>
   action$.ofType('FIRST')
     .mapTo({
       type: 'first',
       payload: store.getState()
     });
 
-const epic2: Epic<FluxStandardAction> = (action$, store) =>
+const epic2: Epic<FluxStandardAction, any> = (action$, store) =>
   action$.ofType('SECOND', 'NEVER')
     .mapTo('second')
     .mergeMap(type => Observable.of({ type }));
 
-const epic3: Epic<FluxStandardAction> = action$ =>
+const epic3: Epic<FluxStandardAction, any> = action$ =>
   action$.ofType('THIRD')
     .mapTo({
       type: 'third'
     });
 
-const epic4: Epic<FluxStandardAction> = () =>
+const epic4: Epic<FluxStandardAction, any> = () =>
   Observable.of({
     type: 'fourth'
   });
 
-const epic5: Epic<FluxStandardAction> = (action$, store) =>
+const epic5: Epic<FluxStandardAction, any> = (action$, store) =>
   action$.ofType('FIFTH')
     .flatMap(({ type, payload }) => Observable.of({
       type: 'fifth',
@@ -54,10 +54,10 @@ const epic6 = (action$, store) =>
       payload
     }));
 
-const rootEpic1: Epic<FluxStandardAction> = combineEpics<FluxStandardAction>(epic1, epic2, epic3, epic4, epic5, epic6);
+const rootEpic1: Epic<FluxStandardAction, any> = combineEpics<FluxStandardAction, any>(epic1, epic2, epic3, epic4, epic5, epic6);
 const rootEpic2 = combineEpics(epic1, epic2, epic3, epic4, epic5, epic6);
 
-const epicMiddleware1: EpicMiddleware<FluxStandardAction> = createEpicMiddleware<FluxStandardAction>(rootEpic1);
+const epicMiddleware1: EpicMiddleware<FluxStandardAction, any> = createEpicMiddleware<FluxStandardAction, any>(rootEpic1);
 const epicMiddleware2 = createEpicMiddleware(rootEpic2);
 
 const reducer = (state = [], action) => state.concat(action);

--- a/typings.json
+++ b/typings.json
@@ -1,6 +1,0 @@
-{
-  "globalDependencies": {
-    "chai": "registry:dt/chai#3.4.0+20160601211834",
-    "es6-shim": "registry:dt/es6-shim#0.31.2+20160602141504"
-  }
-}


### PR DESCRIPTION
Closes #172

Also includes a couple of TypeScript-related fixes:

* redux now includes its own types, so @types/redux isn’t needed
* typings.json isn’t used anymore

- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.