### PR TITLE
feat(ActionsObservable.ofType): allow passing action creators with a toString

### DIFF
--- a/src/ActionsObservable.js
+++ b/src/ActionsObservable.js
@@ -27,10 +27,10 @@ export class ActionsObservable extends Observable {
     return this::filter(({ type }) => {
       const len = keys.length;
       if (len === 1) {
-        return type === keys[0];
+        return type === keys[0].toString();
       } else {
         for (let i = 0; i < len; i++) {
-          if (keys[i] === type) {
+          if (keys[i].toString() === type) {
             return true;
           }
         }

--- a/test/ActionsObservable-spec.js
+++ b/test/ActionsObservable-spec.js
@@ -76,5 +76,44 @@ describe('ActionsObservable', () => {
       expect(lulz).to.deep.equal([{ type: 'LULZ', i: 0 }, { type: 'LARF', i: 1 }]);
       expect(haha).to.deep.equal([{ type: 'HAHA', i: 0 }]);
     });
+
+    it('should handle action creator with a toString', () => {
+      let actions = new Subject();
+      let actionsObs = new ActionsObservable(actions);
+      let lulz = [];
+      let haha = [];
+
+      const createAction = (type) => {
+        const actionCreator = () => {
+          const action = {
+            type
+          };
+          return action;
+        };
+
+        actionCreator.toString = () => type.toString();
+        return actionCreator;
+      };
+      const doLulz = createAction('LULZ');
+      const doHaha = createAction('HAHA');
+
+      actionsObs.ofType(doLulz).subscribe(x => lulz.push(x));
+      actionsObs.ofType(doHaha).subscribe(x => haha.push(x));
+
+      actions.next({ type: 'LULZ', i: 0 });
+
+      expect(lulz).to.deep.equal([{ type: 'LULZ', i: 0 }]);
+      expect(haha).to.deep.equal([]);
+
+      actions.next({ type: 'LULZ', i: 1 });
+
+      expect(lulz).to.deep.equal([{ type: 'LULZ', i: 0 }, { type: 'LULZ', i: 1 }]);
+      expect(haha).to.deep.equal([]);
+
+      actions.next({ type: 'HAHA', i: 0 });
+
+      expect(lulz).to.deep.equal([{ type: 'LULZ', i: 0 }, { type: 'LULZ', i: 1 }]);
+      expect(haha).to.deep.equal([{ type: 'HAHA', i: 0 }]);
+    });
   });
 });


### PR DESCRIPTION
Use case for this is using the [redux-actions](https://github.com/acdlite/redux-actions) repo to make action creators and using those instead of constants in the ofType.

Biggest win is in the case of following a ducks pattern and not wanting to export the constants.  You can see a super simplified action creator in the test on this branch as an example.

<!-- If this is your first PR for redux-observable, please mark these boxes to confirm (otherwise you can exclude them)-->

- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.
