### PR TITLE
chore(build): upgrade to webpack2, webpack-rxjs-externals@1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,6 @@
     "sinon": "1.17.7",
     "typescript": "^2.1.4",
     "webpack": "^2.2.1",
-    "webpack-rxjs-externals": "~0.0.4"
+    "webpack-rxjs-externals": "~1.0.0"
   }
 }

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,5 +1,5 @@
 import webpack from 'webpack';
-import createRxJSExternals from 'webpack-rxjs-externals';
+import webpackRxjsExternals from 'webpack-rxjs-externals';
 
 const env = process.env.NODE_ENV;
 
@@ -13,15 +13,15 @@ const config = {
     library: 'ReduxObservable',
     libraryTarget: 'umd'
   },
-  externals: {
-    ...createRxJSExternals(),
+  externals: [
+    webpackRxjsExternals(), {
     redux: {
       root: 'Redux',
       commonjs2: 'redux',
       commonjs: 'redux',
       amd: 'redux'
     }
-  },
+  }],
   plugins: [
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.DefinePlugin({


### PR DESCRIPTION
[webpack-rxjs-externals API changed](https://github.com/jayphelps/webpack-rxjs-externals/pull/2) slightly, this upgrades it and our externals to the new format.