### PR TITLE
chore(rxjs): update rxjs to v5 non-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Install
 
-This has peer dependencies of `rxjs@5.0.*` and `redux`, which will have to be installed as well.
+This has peer dependencies of `rxjs@5.x.x` and `redux`, which will have to be installed as well.
 
 ```bash
 npm install --save redux-observable

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "homepage": "https://github.com/redux-observable/redux-observable#README.md",
   "peerDependencies": {
     "redux": "3.*",
-    "rxjs": "^5.0.0-beta.10"
+    "rxjs": "^5.0.0"
   },
   "devDependencies": {
     "@types/chai": "^3.4.34",
@@ -93,7 +93,7 @@
     "mocha": "^3.0.1",
     "redux": "^3.5.2",
     "rimraf": "^2.5.4",
-    "rxjs": "^5.0.0-beta.10",
+    "rxjs": "^5.0.0",
     "sinon": "1.17.7",
     "typescript": "^2.1.4",
     "webpack": "^2.2.1",


### PR DESCRIPTION
BREAKING CHANGE:

RxJS v5 non-beta (e.g. 5.1.0) is now required. Upgrading from rxjs 5
beta to latest should be easy in most cases.

![image](https://cloud.githubusercontent.com/assets/762949/22841022/b6eb13c0-ef84-11e6-8a6f-28b124a415db.png)

