### PR TITLE
fix(typings): Add combineEpics overload for custom Epic signatures

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,7 @@ export interface EpicMiddleware<T, S> extends Middleware {
   replaceEpic(nextEpic: Epic<T, S>): void;
 }
 
-interface Adapter { 
+interface Adapter {
   input: (input$: Observable<any>) => any;
   output: (output$: any) => Observable<any>;
 }
@@ -47,3 +47,4 @@ interface Options {
 export declare function createEpicMiddleware<T, S>(rootEpic: Epic<T, S>, options?: Options): EpicMiddleware<T, S>;
 
 export declare function combineEpics<T, S>(...epics: Epic<T, S>[]): Epic<T, S>;
+export declare function combineEpics<E>(...epics: E[]): E;

--- a/test/typings.ts
+++ b/test/typings.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { createStore, applyMiddleware } from 'redux';
+import { createStore, applyMiddleware, MiddlewareAPI } from 'redux';
 import { Observable } from 'rxjs/Observable';
 import { asap } from 'rxjs/scheduler/asap';
 import 'rxjs/add/observable/of';
@@ -59,6 +59,26 @@ const rootEpic2 = combineEpics(epic1, epic2, epic3, epic4, epic5, epic6);
 
 const epicMiddleware1: EpicMiddleware<FluxStandardAction, any> = createEpicMiddleware<FluxStandardAction, any>(rootEpic1);
 const epicMiddleware2 = createEpicMiddleware(rootEpic2);
+
+interface CustomEpic<T, S, U> {
+  (action$: ActionsObservable<T>, store: MiddlewareAPI<S>, api: U): Observable<T>;
+}
+
+const customEpic: CustomEpic<FluxStandardAction, any, number> = (action$, store, some) =>
+  action$.ofType('CUSTOM1')
+    .map(({ type, payload }) => ({
+      type: 'custom1',
+      payload
+    }));
+
+const customEpic2 = (action$, store, some) =>
+  action$.ofType('CUSTOM2')
+    .map(({ type, payload }) => ({
+      type: 'custom2',
+      payload
+    }));
+
+const combinedCustomEpics = combineEpics<CustomEpic<FluxStandardAction, any, any>>(customEpic, customEpic2);
 
 const reducer = (state = [], action) => state.concat(action);
 const store = createStore(


### PR DESCRIPTION
<!-- If this is your first PR for redux-observable, please mark these boxes to confirm (otherwise you can exclude them)-->

- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.

I try to use API injection epic pattern that like https://github.com/redux-observable/redux-observable/issues/84#issuecomment-236042600 and #163.

But current typing is not accept `combineEpics` with extra argument epics.