### PR TITLE
fix(typings): Add dependencies to middleware options.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ export declare class ActionsObservable<T> extends Observable<T> {
    * because we would need non-final position spread params e.g.
    *   `static of<T>(...items: T, scheduler?: Scheduler): ActionsObservable<T>`
    * which isn't possible in either JavaScript or TypeScript. So instead, we
-   * provide safe typing for up to 6 items, following by a scheduler. 
+   * provide safe typing for up to 6 items, following by a scheduler.
    */
   static of<T>(item1: T, scheduler?: Scheduler): ActionsObservable<T>;
   static of<T>(item1: T, item2: T, scheduler?: Scheduler): ActionsObservable<T>;
@@ -42,6 +42,7 @@ interface Adapter {
 
 interface Options {
   adapter?: Adapter;
+  dependencies: { [key:string]: any }
 }
 
 export declare function createEpicMiddleware<T, S>(rootEpic: Epic<T, S>, options?: Options): EpicMiddleware<T, S>;

--- a/test/typings.ts
+++ b/test/typings.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { createStore, applyMiddleware, MiddlewareAPI } from 'redux';
 import { Observable } from 'rxjs/Observable';
+import { ajax } from 'rxjs/observable/dom/ajax';
 import { asap } from 'rxjs/scheduler/asap';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/mapTo';
@@ -77,6 +78,10 @@ const customEpic2 = (action$, store, some) =>
       type: 'custom2',
       payload
     }));
+
+const customEpicMiddleware: EpicMiddleware<FluxStandardAction, any> = createEpicMiddleware<FluxStandardAction, any>(rootEpic1, {
+  dependencies: { getJSON: ajax.getJSON }
+});
 
 const combinedCustomEpics = combineEpics<CustomEpic<FluxStandardAction, any, any>>(customEpic, customEpic2);
 


### PR DESCRIPTION
Update TypeScript types to v0.14

- 0.14 Added `dependencies` to the options of `createEpicMiddleware`. Added them to the typings and added it to the tests.

If you want some more strict typings let me know.

---

- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.
