### PR TITLE
fix(typings): lift now uses correct return type, instead of `any`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,8 @@ export declare class ActionsObservable<T> extends Observable<T> {
   static from<T, R>(ish: ArrayLike<T>, scheduler?: Scheduler): ActionsObservable<R>;
 
   constructor(input$: Observable<T>);
-  lift(operator: Operator<any, T>): ActionsObservable<T>;
+  lift<R>(operator: Operator<T, R>): ActionsObservable<R>;
+  ofType(...key: string[]): ActionsObservable<T>;
   ofType(...key: any[]): ActionsObservable<T>;
 }
 


### PR DESCRIPTION
fixes #187
