### PR TITLE
Proposal: Add a transformEpic helper

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -50,3 +50,5 @@ export declare function createEpicMiddleware<T, S>(rootEpic: Epic<T, S>, options
 
 export declare function combineEpics<T, S>(...epics: Epic<T, S>[]): Epic<T, S>;
 export declare function combineEpics<E>(...epics: E[]): E;
+
+export declare function transformEpic<T, S>(epic: Epic<T, S>, transformer: Epic<T, S>): Epic<T, S>;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 export { createEpicMiddleware } from './createEpicMiddleware';
 export { ActionsObservable } from './ActionsObservable';
 export { combineEpics } from './combineEpics';
+export { transformEpic } from './transformEpic';
 export { EPIC_END } from './EPIC_END';

--- a/src/transformEpic.js
+++ b/src/transformEpic.js
@@ -1,0 +1,7 @@
+import { ActionsObservable } from './ActionsObservable';
+
+export const transformEpic = (epic, transformer) => (action$, store) =>
+  transformer(
+    ActionsObservable.from(epic(action$, store)),
+    store
+  );

--- a/test/transformEpic-spec.js
+++ b/test/transformEpic-spec.js
@@ -1,0 +1,64 @@
+/* globals describe it */
+import { expect } from 'chai';
+import { transformEpic, ActionsObservable } from '../';
+import { Subject } from 'rxjs/Subject';
+import { map } from 'rxjs/operator/map';
+import { _catch } from 'rxjs/operator/catch';
+import { of } from 'rxjs/observable/of';
+
+describe('transformEpic', () => {
+  it('should transform an epic', () => {
+    const epicInput = (actions, store) =>
+      actions.ofType('ACTION1')::map(action => ({ type: 'DELEGATED1', action, store }));
+    const transformer = (actions, store) =>
+      actions.ofType('DELEGATED1')::map(action => ({ type: 'DELEGATED2', action, store }));
+
+    const epic = transformEpic(
+      epicInput,
+      transformer
+    );
+
+    const store = { I: 'am', a: 'store' };
+    const subject = new Subject();
+    const actions = new ActionsObservable(subject);
+    const result = epic(actions, store);
+    const emittedActions = [];
+
+    result.subscribe(emittedAction => emittedActions.push(emittedAction));
+
+    const triggerAction = { type: 'ACTION1' };
+    subject.next(triggerAction);
+
+    expect(emittedActions).to.deep.equal([
+      { type: 'DELEGATED2', action: { type: 'DELEGATED1', action: triggerAction, store }, store },
+    ]);
+  });
+
+  it('should work if the underlying epic errors', () => {
+    const error = new Error('test');
+
+    const epicInput = (actions, store) =>
+      actions.ofType('ACTION1')::map(action => { throw error; });
+    const transformer = (actions, store) =>
+      actions::_catch(err => of({ type: 'ERROR', error: err }));
+
+    const epic = transformEpic(
+      epicInput,
+      transformer
+    );
+
+    const store = { I: 'am', a: 'store' };
+    const subject = new Subject();
+    const actions = new ActionsObservable(subject);
+    const result = epic(actions, store);
+    const emittedActions = [];
+
+    result.subscribe(emittedAction => emittedActions.push(emittedAction));
+
+    subject.next({ type: 'ACTION1' });
+
+    expect(emittedActions).to.deep.equal([
+      { type: 'ERROR', error }
+    ]);
+  });
+});


### PR DESCRIPTION
I recently ran into a minor problem and came up with a small solution. I thought I should just send a PR, since I already have the code, and it should be easier to understand this way :smile:

It's a `transformEpic` helper that takes an epic changes it with a transformer that is an epic itself. The signature is thus:

```ts
transformEpic(epic: Epic<T, S>, transformer: Epic<T, S): Epic<T, S>
```

In a project I ran into a problem, where I need to catch all errors on every epic to have a fallback. Thus I want to `combineEpics` to create a root epic, then create another epic, that wraps around the root epic, executes it, and calls `catch` on action$.

```ts
transformEpic(
  rootEpic,
  action$ => action$::_catch(err =>of({ type: 'SET_ERROR_STATE', payload: err })
)
```

This might be nicer than doing this, especially in TypeScript:

```
(...args) => rootEpic(...args)::_catch(err =>of({ type: 'SET_ERROR_STATE', payload: err })
```

I realise this is really just about semantics, but finally I'm able to find an excuse to contribute to redux-observable :laughing:

<!-- If this is your first PR for redux-observable, please mark these boxes to confirm (otherwise you can exclude them)-->

- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.
