### PR TITLE
Add generic option for `ofType` (TypeScript).

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,7 @@ export declare class ActionsObservable<T> extends Observable<T> {
   constructor(input$: Observable<T>);
   lift<R>(operator: Operator<T, R>): ActionsObservable<R>;
   ofType(...key: string[]): ActionsObservable<T>;
+  ofType<A extends string>(...key: A[]): ActionsObservable<T>;
   ofType(...key: any[]): ActionsObservable<T>;
 }
 


### PR DESCRIPTION
Adds a type definition allowing the `ActionsObservable.ofType` method to take a strongly typed action name.

## Example:

    const fooEpic = (action$: ActionsObservable<IMyAction>) =>
      action$
        .ofType<IMyAction['type']>('@module/LOAD')

## Rationale:
This allows renaming of strongly typed action string (in say VSCode), which will update all references to the "magic string" across a project.
