### PR TITLE
docs(examples): porting of the redux saga cancellable counter example

### DIFF
--- a/examples/redux-observable-cancellable-counter/.babelrc
+++ b/examples/redux-observable-cancellable-counter/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "stage-0", "react"]
+}

--- a/examples/redux-observable-cancellable-counter/.gitignore
+++ b/examples/redux-observable-cancellable-counter/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+build
+.idea
+*.iml

--- a/examples/redux-observable-cancellable-counter/README.md
+++ b/examples/redux-observable-cancellable-counter/README.md
@@ -1,0 +1,14 @@
+## redux observable cancellable counter ##
+
+This is the porting of the redux saga cancellable counter example.
+It's slightly different from the original one in the management on how the initial epic is started, and terminated.
+
+Package with:
+
+    npm run webpack
+    
+run with:
+
+    npm start
+    
+    

--- a/examples/redux-observable-cancellable-counter/index.html
+++ b/examples/redux-observable-cancellable-counter/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+</head>
+<body>
+<h1>Cancellable counter</h1>
+<div id="root"></div>
+<script src="build/app.bundle.js"></script>
+</body>
+</html>
+

--- a/examples/redux-observable-cancellable-counter/js/actionTypes.js
+++ b/examples/redux-observable-cancellable-counter/js/actionTypes.js
@@ -1,0 +1,12 @@
+
+// Action types
+export const INCREMENT = 'INCREMENT';
+export const DECREMENT = 'DECREMENT';
+export const INCREMENT_IF_ODD = 'INCREMENT_IF_ODD';
+
+export const INCREMENT_ASYNC = 'INCREMENT_ASYNC';
+export const CANCEL_INCREMENT_ASYNC = 'CANCEL_INCREMENT_ASYNC';
+// this action does not exist in the redux saga example.
+export const START_COUNTDOWN = 'START_COUNTDOWN';
+// this action is not used anymore instead.
+export const COUNTDOWN_TERMINATED = 'COUNTDOWN_TERMINATED';

--- a/examples/redux-observable-cancellable-counter/js/components/Counter.js
+++ b/examples/redux-observable-cancellable-counter/js/components/Counter.js
@@ -1,0 +1,57 @@
+/*eslint-disable no-unused-vars*/
+import React, { PropTypes } from 'react'
+import { connect } from 'react-redux'
+
+import {
+  INCREMENT,
+  DECREMENT,
+  INCREMENT_IF_ODD,
+  INCREMENT_ASYNC,
+  CANCEL_INCREMENT_ASYNC,
+  HIDE_CONGRATULATION,
+  START_COUNTDOWN
+} from '../actionTypes'
+
+
+function Counter({counter, countdown, congratulate, dispatch}) {
+
+      const action = (type, value) => () => dispatch({type, value});
+
+      return (
+        <div>
+          Clicked: {counter} times
+          {' '}
+          <button onClick={action(INCREMENT)}>+</button>
+          {' '}
+          <button onClick={action(DECREMENT)}>-</button>
+          {' '}
+          <button onClick={action(INCREMENT_IF_ODD)}>Increment if odd</button>
+          {' '}
+          <button
+            onClick={countdown ? action(CANCEL_INCREMENT_ASYNC) : action(START_COUNTDOWN)}
+            style={{color: countdown ? 'red' : 'black'}}>
+
+            {countdown ? `Cancel increment (${countdown})` : 'increment after 5s'}
+          </button>
+        </div>
+      )
+}
+
+
+
+Counter.propTypes = {
+  // dispatch actions
+  dispatch: PropTypes.func.isRequired,
+  // state
+  counter: PropTypes.number.isRequired,
+  countdown: PropTypes.number.isRequired
+}
+
+function mapStateToProps(state) {
+  return {
+    counter: state.counter,
+    countdown: state.countdown
+  }
+}
+
+export default connect(mapStateToProps)(Counter)

--- a/examples/redux-observable-cancellable-counter/js/epics/index.js
+++ b/examples/redux-observable-cancellable-counter/js/epics/index.js
@@ -1,0 +1,59 @@
+import 'rxjs';
+import { Observable } from 'rxjs/Observable';
+import { combineEpics } from 'redux-observable';
+import { START_COUNTDOWN, INCREMENT_ASYNC, INCREMENT, CANCEL_INCREMENT_ASYNC } from '../actionTypes';
+
+const startCountdownEpic = (action$) => {
+  /*
+   * This action does not exist in the corresponding redux saga example: it's used to isolate
+   * better a single countdown worflow.
+   */
+  return action$.ofType(START_COUNTDOWN).switchMap(q => {
+
+    const start = 5;
+
+    /*
+     * A countdown generates a 5,4,3,2,1,0,-1 series of events,
+     * where all are separated by 1 second but the last one (-1), that is only
+     * 10 milliseconds away from 0.
+     * This way, when the counter hit 0 the "INCREMENT_ASYNC" is dispatched,
+     * so the counter becomes 0 again and, when it dispatches -1
+     * (10 milliseconds later), the actual increment is dispatched at last.
+     */
+    return Observable
+      .timer(0, 1000)
+      .mergeMap(tick => {
+        //when we reach 5 we schedule 5 and 6.
+        if (tick === start) {
+          return Observable.timer(0, 10).mergeMap(y => Observable.of(start, start + 1))
+        }
+        else {
+          return Observable.of(tick)
+        }
+      })
+      .map(i => start - i)
+      .take(start + 2)
+      // supports cancellation
+      .takeUntil(action$.ofType(CANCEL_INCREMENT_ASYNC))
+      .map(seconds => {
+        // actual increment action
+        if (seconds === -1) {
+          return { type: INCREMENT }
+        }
+        // increment async action
+        else {
+          return { type: INCREMENT_ASYNC, value: seconds }
+        }
+      });
+  });
+};
+
+/**
+ * there is only one epic.
+ */
+export const rootEpic = combineEpics(
+  startCountdownEpic
+);
+
+
+

--- a/examples/redux-observable-cancellable-counter/js/main.js
+++ b/examples/redux-observable-cancellable-counter/js/main.js
@@ -1,0 +1,31 @@
+/**
+ * The new saga that uses redux observable.
+ */
+import "babel-polyfill"
+
+import React from 'react'
+import { render } from 'react-dom'
+import { Provider, ReactRedux } from 'react-redux'
+import { createStore, applyMiddleware } from 'redux'
+import reducer from './reducers'
+import Counter from './components/Counter'
+import 'rxjs';
+import { createEpicMiddleware } from 'redux-observable';
+import { rootEpic } from './epics';
+
+const epicMiddleware = createEpicMiddleware(rootEpic);
+
+/**
+ * this is the Redux state store.
+ */
+const store = createStore(
+  reducer,
+  applyMiddleware(epicMiddleware)
+);
+
+render(
+  <Provider store={store}>
+    <Counter />
+  </Provider>,
+  document.getElementById('root')
+);

--- a/examples/redux-observable-cancellable-counter/js/mainWithSaga.js
+++ b/examples/redux-observable-cancellable-counter/js/mainWithSaga.js
@@ -1,0 +1,31 @@
+/**
+ * The original main that uses redux-saga.
+ * To use it change the webpack.config.js
+ */
+import "babel-polyfill"
+
+import React from 'react'
+import { render } from 'react-dom'
+import { Provider } from 'react-redux'
+import { createStore, applyMiddleware } from 'redux'
+import createSagaMiddleware from 'redux-saga'
+import sagaMonitor from './sagaMonitor'
+
+import reducer from './reducers'
+import rootSaga from './sagas'
+import Counter from './components/Counter'
+
+
+const sagaMiddleware = createSagaMiddleware({sagaMonitor})
+const store = createStore(
+  reducer,
+  applyMiddleware(sagaMiddleware)
+)
+sagaMiddleware.run(rootSaga)
+
+render(
+  <Provider store={store}>
+    <Counter />
+  </Provider>,
+  document.getElementById('root')
+)

--- a/examples/redux-observable-cancellable-counter/js/reducers/counter.js
+++ b/examples/redux-observable-cancellable-counter/js/reducers/counter.js
@@ -1,0 +1,35 @@
+import {
+  INCREMENT,
+  DECREMENT,
+  INCREMENT_IF_ODD,
+  INCREMENT_ASYNC,
+  CANCEL_INCREMENT_ASYNC,
+  COUNTDOWN_TERMINATED
+} from '../actionTypes'
+
+export function countdown(state = 0, action) {
+  switch (action.type) {
+    case INCREMENT_ASYNC:
+      return action.value
+    case COUNTDOWN_TERMINATED:
+    case CANCEL_INCREMENT_ASYNC:
+      return 0;
+    default:
+      return state
+  }
+}
+
+
+
+export function counter(state = 0, action) {
+  switch (action.type) {
+    case INCREMENT:
+      return state + 1
+    case DECREMENT:
+      return state - 1
+    case INCREMENT_IF_ODD:
+      return state % 2 ? state + 1 : state
+    default:
+      return state
+  }
+}

--- a/examples/redux-observable-cancellable-counter/js/reducers/index.js
+++ b/examples/redux-observable-cancellable-counter/js/reducers/index.js
@@ -1,0 +1,9 @@
+import { combineReducers } from 'redux'
+import { counter, countdown } from './counter'
+
+const rootReducer = combineReducers({
+  countdown,
+  counter
+})
+
+export default rootReducer

--- a/examples/redux-observable-cancellable-counter/js/sagaMonitor/index.js
+++ b/examples/redux-observable-cancellable-counter/js/sagaMonitor/index.js
@@ -1,0 +1,426 @@
+/*eslint-disable no-console*/
+
+import { is, asEffect } from 'redux-saga/utils'
+
+const PENDING = 'PENDING'
+const RESOLVED = 'RESOLVED'
+const REJECTED = 'REJECTED'
+const CANCELLED = 'CANCELLED'
+
+const DEFAULT_STYLE = 'color: black'
+const LABEL_STYLE = 'font-weight: bold'
+const EFFECT_TYPE_STYLE = 'color: blue'
+const ERROR_STYLE = 'color: red'
+const CANCEL_STYLE = 'color: #ccc'
+
+const IS_BROWSER = (typeof window !== 'undefined' && window.document)
+
+const globalScope = (
+  typeof window.document === 'undefined' && navigator.product === 'ReactNative' ? global
+  : IS_BROWSER ? window
+  : null
+)
+
+// `VERBOSE` can be made a setting configured from the outside.
+const VERBOSE = false
+
+function time() {
+  if(typeof performance !== 'undefined' && performance.now) {
+    return performance.now()
+  } else {
+    return Date.now()
+  }
+}
+
+let effectsById = {}
+const rootEffects = []
+
+function effectTriggered(desc) {
+  if (VERBOSE) {
+    console.log('Saga monitor: effectTriggered:', desc)
+  }
+  effectsById[desc.effectId] = Object.assign({},
+    desc,
+    {
+      status: PENDING,
+      start: time()
+    }
+  )
+  if(desc.root) {
+    rootEffects.push(desc.effectId)
+  }
+}
+
+function effectResolved(effectId, result) {
+  if (VERBOSE) {
+    console.log('Saga monitor: effectResolved:', effectId, result)
+  }
+  resolveEffect(effectId, result)
+}
+
+function effectRejected(effectId, error) {
+  if (VERBOSE) {
+    console.log('Saga monitor: effectRejected:', effectId, error)
+  }
+  rejectEffect(effectId, error)
+}
+
+function effectCancelled(effectId) {
+  if (VERBOSE) {
+    console.log('Saga monitor: effectCancelled:', effectId)
+  }
+  cancelEffect(effectId)
+}
+
+function computeEffectDur(effect) {
+  const now = time()
+  Object.assign(effect, {
+    end: now,
+    duration: now - effect.start
+  })
+}
+
+function resolveEffect(effectId, result) {
+  const effect = effectsById[effectId]
+
+  if(is.task(result)) {
+    result.done.then(
+      taskResult => {
+        if(result.isCancelled()) {
+          cancelEffect(effectId)
+        } else {
+          resolveEffect(effectId, taskResult)
+        }
+      },
+      taskError  => rejectEffect(effectId, taskError)
+    )
+  } else {
+    computeEffectDur(effect)
+    effect.status = RESOLVED
+    effect.result = result
+    if(effect && asEffect.race(effect.effect)) {
+      setRaceWinner(effectId, result)
+    }
+  }
+}
+
+function rejectEffect(effectId, error) {
+  const effect = effectsById[effectId]
+  computeEffectDur(effect)
+  effect.status = REJECTED
+  effect.error = error
+  if(effect && asEffect.race(effect.effect)) {
+    setRaceWinner(effectId, error)
+  }
+}
+
+function cancelEffect(effectId) {
+  const effect = effectsById[effectId]
+  computeEffectDur(effect)
+  effect.status = CANCELLED
+}
+
+function setRaceWinner(raceEffectId, result) {
+  const winnerLabel = Object.keys(result)[0]
+  const children = getChildEffects(raceEffectId)
+  for (var i = 0; i < children.length; i++) {
+    const childEffect = effectsById[ children[i] ]
+    if(childEffect.label === winnerLabel) {
+      childEffect.winner = true
+    }
+  }
+}
+
+function getChildEffects(parentEffectId) {
+  return Object.keys(effectsById)
+    .filter(effectId => effectsById[effectId].parentEffectId === parentEffectId)
+    .map(effectId => +effectId)
+}
+
+// Poor man's `console.group` and `console.groupEnd` for Node.
+// Can be overridden by the `console-group` polyfill.
+// The poor man's groups look nice, too, so whether to use
+// the polyfilled methods or the hand-made ones can be made a preference.
+let groupPrefix = '';
+const GROUP_SHIFT = '   ';
+const GROUP_ARROW = '▼';
+
+function consoleGroup(...args) {
+  if(console.group) {
+    console.group(...args)
+  } else {
+    console.log('')
+    console.log(groupPrefix + GROUP_ARROW, ...args)
+    groupPrefix += GROUP_SHIFT
+  }
+}
+
+function consoleGroupEnd() {
+  if(console.groupEnd) {
+    console.groupEnd()
+  } else {
+    groupPrefix = groupPrefix.substr(0, groupPrefix.length - GROUP_SHIFT.length)
+  }
+}
+
+function logEffects(topEffects) {
+  topEffects.forEach(logEffectTree)
+}
+
+function logEffectTree(effectId) {
+  const effect = effectsById[effectId]
+  const childEffects = getChildEffects(effectId)
+
+  if(!childEffects.length) {
+    logSimpleEffect(effect)
+  } else {
+    const {formatter} = getEffectLog(effect)
+    consoleGroup(...formatter.getLog())
+    childEffects.forEach(logEffectTree)
+    consoleGroupEnd()
+  }
+}
+
+function logSimpleEffect(effect) {
+  const {method, formatter} = getEffectLog(effect)
+  console[method](...formatter.getLog())
+}
+
+/*eslint-disable no-cond-assign*/
+function getEffectLog(effect) {
+  let data, log
+
+  if(effect.root) {
+    data = effect.effect
+    log = getLogPrefix('run', effect)
+    log.formatter.addCall(data.saga.name, data.args)
+    logResult(effect, log.formatter)
+  }
+  else if(data = asEffect.take(effect.effect)) {
+    log = getLogPrefix('take', effect)
+    log.formatter.addValue(data)
+    logResult(effect, log.formatter)
+  }
+  else if(data = asEffect.put(effect.effect)) {
+    log = getLogPrefix('put', effect)
+    logResult(Object.assign({}, effect, { result: data }), log.formatter)
+  }
+  else if(data = asEffect.call(effect.effect)) {
+    log = getLogPrefix('call', effect)
+    log.formatter.addCall(data.fn.name, data.args)
+    logResult(effect, log.formatter)
+  }
+  else if(data = asEffect.cps(effect.effect)) {
+    log = getLogPrefix('cps', effect)
+    log.formatter.addCall(data.fn.name, data.args)
+    logResult(effect, log.formatter)
+  }
+  else if(data = asEffect.fork(effect.effect)) {
+    if(!data.detached) {
+      log = getLogPrefix('fork', effect)
+    } else {
+      log = getLogPrefix('spawn', effect)
+    }
+    log.formatter.addCall(data.fn.name, data.args)
+    logResult(effect, log.formatter)
+  }
+  else if(data = asEffect.join(effect.effect)) {
+    log = getLogPrefix('join', effect)
+    logResult(effect, log.formatter)
+  }
+  else if(data = asEffect.race(effect.effect)) {
+    log = getLogPrefix('race', effect)
+    logResult(effect, log.formatter, true)
+  }
+  else if(data = asEffect.cancel(effect.effect)) {
+    log = getLogPrefix('cancel', effect)
+    log.formatter.appendData(data.name)
+  }
+  else if(data = asEffect.select(effect.effect)) {
+    log = getLogPrefix('select', effect)
+    log.formatter.addCall(data.selector.name, data.args)
+    logResult(effect, log.formatter)
+  }
+  else if(is.array(effect.effect)) {
+    log = getLogPrefix('parallel', effect)
+    logResult(effect, log.formatter, true)
+  }
+  else if(is.iterator(effect.effect)) {
+    log = getLogPrefix('', effect)
+    log.formatter.addValue(effect.effect.name)
+    logResult(effect, log.formatter, true)
+  }
+  else {
+    log = getLogPrefix('unkown', effect)
+    logResult(effect, log.formatter)
+  }
+
+  return log
+}
+
+
+function getLogPrefix(type, effect) {
+
+  const isCancel = effect.status === CANCELLED
+  const isError = effect.status === REJECTED
+
+  const method = isError ? 'error' : 'log'
+  const winnerInd = effect && effect.winner
+    ? ( isError ? '✘' : '✓' )
+    : ''
+
+  const style = s =>
+      isCancel  ? CANCEL_STYLE
+    : isError     ? ERROR_STYLE
+    : s
+
+  const formatter = logFormatter()
+
+  if(winnerInd) {
+    formatter.add(`%c ${winnerInd}`, style(LABEL_STYLE))
+  }
+  if(effect && effect.label) {
+    formatter.add(`%c ${effect.label}: `,  style(LABEL_STYLE))
+  }
+  if(type) {
+    formatter.add(`%c ${type} `, style(EFFECT_TYPE_STYLE))
+  }
+  formatter.add('%c', style(DEFAULT_STYLE))
+
+  return {
+    method,
+    formatter
+  }
+}
+
+function argToString(arg) {
+  return (
+      typeof arg === 'function' ? `${arg.name}`
+    : typeof arg === 'string'   ? `'${arg}'`
+    : arg
+  )
+}
+
+function logResult({status, result, error, duration}, formatter, ignoreResult) {
+
+  if(status === RESOLVED && !ignoreResult) {
+    if( is.array(result) ) {
+      formatter.addValue(' → ')
+      formatter.addValue(result)
+    } else {
+      formatter.appendData('→',result)
+    }
+  }
+  else if(status === REJECTED) {
+    formatter.appendData('→ ⚠', error)
+  }
+  else if(status === PENDING) {
+    formatter.appendData('⌛')
+  }
+  else if(status === CANCELLED) {
+    formatter.appendData('→ Cancelled!')
+  }
+  if(status !== PENDING) {
+    formatter.appendData(`(${duration.toFixed(2)}ms)`)
+  }
+}
+
+function isPrimitive(val) {
+  return  typeof val === 'string'   ||
+          typeof val === 'number'   ||
+          typeof val === 'boolean'  ||
+          typeof val === 'symbol'   ||
+          val === null              ||
+          val === undefined;
+}
+
+function logFormatter() {
+  const logs = []
+  let suffix = []
+
+  function add(msg, ...args) {
+    // Remove the `%c` CSS styling that is not supported by the Node console.
+    if(!IS_BROWSER && typeof msg === 'string') {
+      const prevMsg = msg
+      msg = msg.replace(/^%c\s*/, '')
+      if(msg !== prevMsg) {
+        // Remove the first argument which is the CSS style string.
+        args.shift()
+      }
+    }
+    logs.push({msg, args})
+  }
+
+  function appendData(...data) {
+    suffix = suffix.concat(data)
+  }
+
+  function addValue(value) {
+    if(isPrimitive(value)) {
+      add(value)
+    } else {
+      // The browser console supports `%O`, the Node console does not.
+      if(IS_BROWSER) {
+        add('%O', value)
+      } else {
+        add('%s', require('util').inspect(value))
+      }
+    }
+  }
+
+  function addCall(name, args) {
+    if(!args.length) {
+      add( `${name}()` )
+    } else {
+      add(name)
+      add('(')
+      args.forEach( (arg, i) => {
+        addValue( argToString(arg) )
+        addValue( i === args.length - 1 ? ')' : ', ')
+      })
+    }
+  }
+
+  function getLog() {
+    let msgs = [], msgsArgs = []
+    for (var i = 0; i < logs.length; i++) {
+      msgs.push(logs[i].msg)
+      msgsArgs = msgsArgs.concat(logs[i].args)
+    }
+    return [msgs.join('')].concat(msgsArgs).concat(suffix)
+  }
+
+  return {
+    add, addValue, addCall, appendData, getLog
+  }
+}
+
+const logSaga = (...topEffects) => {
+  if(!topEffects.length) {
+    topEffects = rootEffects
+  }
+  if(!rootEffects.length) {
+    console.log(groupPrefix, 'Saga monitor: No effects to log')
+  }
+  console.log('')
+  console.log('Saga monitor:', Date.now(), (new Date()).toISOString())
+  logEffects(topEffects)
+  console.log('')
+}
+
+// Export the snapshot-logging function to run from the browser console or extensions.
+if(globalScope) {
+  globalScope.$$LogSagas = logSaga
+}
+
+// Export the snapshot-logging function for arbitrary use by external code.
+export { logSaga }
+
+// Export the `sagaMonitor` to pass to the middleware.
+export default {
+  effectTriggered,
+  effectResolved,
+  effectRejected,
+  effectCancelled,
+  actionDispatched: () => {}
+ }

--- a/examples/redux-observable-cancellable-counter/js/sagas/index.js
+++ b/examples/redux-observable-cancellable-counter/js/sagas/index.js
@@ -1,0 +1,67 @@
+/**
+ * the original saga.
+ */
+import { take, put, call, fork, race, cancelled } from 'redux-saga/effects'
+import { eventChannel, END } from 'redux-saga'
+import { INCREMENT_ASYNC, INCREMENT, CANCEL_INCREMENT_ASYNC, COUNTDOWN_TERMINATED } from '../actionTypes'
+
+const action = type => ({type});
+
+/*eslint-disable no-console*/
+const countdown = (secs) => {
+  console.log('countdown', secs);
+  return eventChannel(listener => {
+      const iv = setInterval(() => {
+        secs -= 1
+        console.log('countdown', secs)
+        if(secs > 0)
+          listener(secs);
+        else {
+          listener(END);
+          clearInterval(iv);
+          console.log('countdown terminated')
+        }
+      }, 1000);
+      return () => {
+        clearInterval(iv);
+        console.log('countdown cancelled')
+      }
+    }
+  )
+}
+
+export function* incrementAsync({value}) {
+  const chan = yield call(countdown, value)
+  try {
+    while(true) {
+      let seconds = yield take(chan)
+      yield put({type: INCREMENT_ASYNC, value: seconds})
+    }
+  } finally {
+    if(!(yield cancelled())) {
+      yield put(action(INCREMENT))
+      yield put(action(COUNTDOWN_TERMINATED))
+    }
+    chan.close()
+  }
+}
+
+export function* watchIncrementAsync() {
+  try {
+    while(true) {
+      const action = yield take(INCREMENT_ASYNC);
+      // starts a 'Race' between an async increment and a user cancel action
+      // if user cancel action wins, the incrementAsync will be cancelled automatically
+      yield race([
+        call(incrementAsync, action),
+        take(CANCEL_INCREMENT_ASYNC)
+      ]);
+    }
+  } finally {
+    console.log('watchIncrementAsync terminated')
+  }
+}
+
+export default function* rootSaga() {
+  yield fork(watchIncrementAsync)
+}

--- a/examples/redux-observable-cancellable-counter/package.json
+++ b/examples/redux-observable-cancellable-counter/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "redux-observable-cancellable-counter",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "webpack": "webpack",
+    "start": "http-server"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "babel-core": "^6.25.0",
+    "babel-loader": "^7.1.1",
+    "babel-preset-es2015": "^6.24.1",
+    "http-server": "^0.10.0",
+    "webpack": "^3.4.1"
+  },
+  "dependencies": {
+    "babel-core": "^6.25.0",
+    "babel-loader": "^7.1.1",
+    "babel-polyfill": "^6.23.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
+    "http-server": "^0.10.0",
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1",
+    "react-redux": "^5.0.5",
+    "redux": "^3.7.2",
+    "redux-observable": "^0.14.1",
+    "redux-saga": "^0.15.6",
+    "webpack": "^3.4.1"
+  },
+  "description": ""
+}

--- a/examples/redux-observable-cancellable-counter/webpack.config.js
+++ b/examples/redux-observable-cancellable-counter/webpack.config.js
@@ -1,0 +1,26 @@
+var path = require('path');
+ var webpack = require('webpack');
+ module.exports = {
+   // use the following for redux saga.
+   // entry: './js/mainWithSaga.js',
+   entry: './js/main.js',
+     output: {
+         path: path.resolve(__dirname, 'build'),
+         filename: 'app.bundle.js'
+     },
+     module: {
+         loaders: [
+             {
+                 test: /\.js$/,
+                 loader: 'babel-loader',
+                 query: {
+                     presets: ['react']
+                 }
+             }
+         ]
+     },
+     stats: {
+         colors: true
+     },
+     devtool: 'source-map'
+ };


### PR DESCRIPTION
I've ported the "redux saga cancellable counter example".
The porting is not 1:1 in terms of middleware adaptations, as I needed to use an extra action. I kept the original saga and the redux saga dependencies as well, so that an user could easily swap the 2 flavours of the examples if he wants to in the `webpack.config.js`. 
If you think this could be misleading I could remove the redux saga part.

Thank you for this fantastic project!

