### PR TITLE
feat(ofType): typed overload (#312)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,7 @@ export declare class ActionsObservable<T extends Action> extends Observable<T> {
   lift<R extends Action>(operator: Operator<T, R>): ActionsObservable<R>;
   lift<R>(operator: Operator<T, R>): Observable<R>;
   ofType(...key: T['type'][]): ActionsObservable<T>;
+  ofType<R extends Action = T>(...key: T['type'][]): ActionsObservable<R>;
 }
 
 export declare interface Epic<T extends Action, S, D = any> {


### PR DESCRIPTION
addition of a narrowing `ofType()` overload.
allows for behavior such as `action$.ofType<SomeNarrowAction>(someType);`

<!-- If this is your first PR for redux-observable, please mark these boxes to confirm (otherwise you can exclude them)-->

- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.
