### PR TITLE
typings: make lettable ofType properly narrow action type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -51,6 +51,6 @@ export declare function createEpicMiddleware<T extends Action, S, D = any, O ext
 export declare function combineEpics<T extends Action, S, D = any, O extends T = T>(...epics: Epic<T, S, D, O>[]): Epic<T, S, D, O>;
 export declare function combineEpics<E>(...epics: E[]): E;
 
-export declare function ofType<T extends Action, R extends T = T>(...keys: T['type'][]): (source: Observable<T>) => Observable<R>;
+export declare function ofType<T extends Action, R extends T = T, K extends R['type'] = R['type']>(...key: K[]): (source: Observable<T>) => Observable<R>;
 
 export declare const EPIC_END: '@@redux-observable/EPIC_END';

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean": "rimraf lib temp dist",
     "check": "npm run lint && npm run test",
     "test": "npm run lint && npm run build && npm run build:tests && mocha temp && npm run test:typings",
-    "test:typings": "tsc --noImplicitAny index.d.ts test/typings.ts --outDir temp --target ES5 --moduleResolution node && cd temp && node typings.js",
+    "test:typings": "tsc --strict index.d.ts test/typings.ts --outDir temp --target ES5 --moduleResolution node && cd temp && node typings.js",
     "shipit": "npm run clean && npm run build && npm run lint && npm test && scripts/preprepublish.sh && npm publish",
     "docs:clean": "rimraf _book",
     "docs:prepare": "gitbook install",

--- a/test/typings.ts
+++ b/test/typings.ts
@@ -208,4 +208,40 @@ const action$1: ActionsObservable<FluxStandardAction> = new ActionsObservable<Fl
 const action$2: ActionsObservable<FluxStandardAction> = ActionsObservable.of<FluxStandardAction>({ type: 'SECOND' }, { type: 'FIRST' }, asap);
 const action$3: ActionsObservable<FluxStandardAction> = ActionsObservable.from<FluxStandardAction>([{ type: 'SECOND' }, { type: 'FIRST' }], asap);
 
+{
+  // proper type narrowing
+  const enum ActionTypes {
+    One = 'ACTION_ONE',
+    Two = 'ACTION_TWO',
+  }
+  const doOne = (myStr: string): One => ({type: ActionTypes.One, myStr})
+  const doTwo = (myBool: boolean): Two => ({type: ActionTypes.Two, myBool})
+
+  interface One extends Action {
+    type: ActionTypes.One
+    myStr: string
+  }
+  interface Two extends Action {
+    type: ActionTypes.Two
+    myBool: boolean
+  }
+  type Actions = One | Two
+
+  // Explicitly set generics fixes the issue
+const epic = (action$: ActionsObservable<Actions>) =>
+  action$
+    .ofType<One>(ActionTypes.One)
+    // action is correctly narrowed to One
+    .map((action) => { console.log(action.myStr) })
+
+// Explicitly set generics fixes the issue
+const epicLettable = (action$: ActionsObservable<Actions>) =>
+  action$.pipe(
+    ofType<Actions,One>(ActionTypes.One),
+    // action is correctly narrowed to One
+    map((action) => { console.log(action.myStr) })
+  );
+
+}
+
 console.log('typings.ts: OK');


### PR DESCRIPTION
- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.

- adds Typescript docs to troubleshooting
- enables strict mode for TS test
- covers proper type narrowing within TS tests


Closes #382 