### PR TITLE
fix(typings): More correct Epic and ofType type refinement (#392)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,16 +25,15 @@ export declare class ActionsObservable<T extends Action> extends Observable<T> {
   constructor(input$: Observable<T>);
   lift<R extends Action>(operator: Operator<T, R>): ActionsObservable<R>;
   lift<R>(operator: Operator<T, R>): Observable<R>;
-  ofType(...key: T['type'][]): ActionsObservable<T>;
-  ofType<R extends Action = T>(...key: R['type'][]): ActionsObservable<R>;
+  ofType<R extends T = T>(...key: R['type'][]): ActionsObservable<R>;
 }
 
-export declare interface Epic<T extends Action, S, D = any> {
-  (action$: ActionsObservable<T>, store: MiddlewareAPI<S>, dependencies: D): Observable<T>;
+export declare interface Epic<T extends Action, S, D = any, O extends T = T> {
+  (action$: ActionsObservable<T>, store: MiddlewareAPI<S>, dependencies: D): Observable<O>;
 }
 
-export interface EpicMiddleware<T extends Action, S, D = any> extends Middleware {
-  replaceEpic(nextEpic: Epic<T, S, D>): void;
+export interface EpicMiddleware<T extends Action, S, D = any, O extends T = T> extends Middleware {
+  replaceEpic(nextEpic: Epic<T, S, D, O>): void;
 }
 
 interface Adapter {
@@ -47,11 +46,11 @@ interface Options<D = any> {
   dependencies?: D;
 }
 
-export declare function createEpicMiddleware<T extends Action, S, D = any>(rootEpic: Epic<T, S, D>, options?: Options<D>): EpicMiddleware<T, S, D>;
+export declare function createEpicMiddleware<T extends Action, S, D = any, O extends T = T>(rootEpic: Epic<T, S, D, O>, options?: Options<D>): EpicMiddleware<T, S, D, O>;
 
-export declare function combineEpics<T extends Action, S, D = any>(...epics: Epic<T, S, D>[]): Epic<T, S, D>;
+export declare function combineEpics<T extends Action, S, D = any, O extends T = T>(...epics: Epic<T, S, D, O>[]): Epic<T, S, D, O>;
 export declare function combineEpics<E>(...epics: E[]): E;
 
-export declare function ofType<T extends Action>(...keys: T['type'][]): (source: Observable<T>) => Observable<T>;
+export declare function ofType<T extends Action, R extends T = T>(...keys: T['type'][]): (source: Observable<T>) => Observable<R>;
 
 export declare const EPIC_END: '@@redux-observable/EPIC_END';

--- a/test/typings.ts
+++ b/test/typings.ts
@@ -80,8 +80,33 @@ const epic8: Epic<FluxStandardAction, State, Dependencies> = (action$, store, de
       }))
     )
 
-const rootEpic1: Epic<FluxStandardAction, State> = combineEpics<FluxStandardAction, State>(epic1, epic2, epic3, epic4, epic5, epic6, epic7, epic8);
-const rootEpic2 = combineEpics(epic1, epic2, epic3, epic4, epic5, epic6, epic7, epic8);
+interface Epic9_Input {
+  type: "NINTH",
+  payload: string,
+}
+interface Epic9_Output {
+  type: "ninth",
+  payload: string,
+}
+
+const epic9_1: Epic<FluxStandardAction, State, Dependencies, Epic9_Output> = (action$, store, dependencies) =>
+  action$.pipe(
+    ofType<FluxStandardAction, Epic9_Input>('NINTH'),
+    map(({ type, payload }) => ({
+      type: 'ninth' as 'ninth',
+      payload: dependencies.func("ninth-" + payload),
+    }))
+  );
+const epic9_2 = (action$: ActionsObservable<FluxStandardAction>, store: MiddlewareAPI<State>, dependencies: Dependencies) =>
+  action$.pipe(
+    ofType<FluxStandardAction, Epic9_Input>('NINTH'),
+    map(({ type, payload }) => ({
+      type: 'ninth',
+      payload: dependencies.func("ninth-" + payload),
+    } as Epic9_Output))
+  );
+const rootEpic1: Epic<FluxStandardAction, State> = combineEpics<FluxStandardAction, State>(epic1, epic2, epic3, epic4, epic5, epic6, epic7, epic8, epic9_1);
+const rootEpic2 = combineEpics(epic1, epic2, epic3, epic4, epic5, epic6, epic7, epic8, epic9_2);
 
 const dependencies: Dependencies = {
   func(value: string) { return `func-${value}`}
@@ -129,6 +154,7 @@ store.dispatch({ type: 'FIFTH', payload: 'fifth-payload' });
 store.dispatch({ type: 'SIXTH', payload: 'sixth-payload' });
 store.dispatch({ type: 'SEVENTH', payload: 'seventh-payload' });
 store.dispatch({ type: 'EIGHTH', payload: 'eighth-payload' });
+store.dispatch({ type: 'NINTH', payload: 'ninth-payload' });
 
 expect(store.getState()).to.deep.equal([
   { "type": "@@redux/INIT" },
@@ -171,7 +197,10 @@ expect(store.getState()).to.deep.equal([
   { "type": "seventh", "payload": "func-seventh-payload" },
   { "type": "EIGHTH", "payload": "eighth-payload" },
   { "type": "eighth", "payload": "eighth-payload" },
-  { "type": "eighth", "payload": "eighth-payload" }
+  { "type": "eighth", "payload": "eighth-payload" },
+  { "type": "NINTH", "payload": "ninth-payload" },
+  { "type": "ninth", "payload": "func-ninth-ninth-payload" },
+  { "type": "ninth", "payload": "func-ninth-ninth-payload" },
 ]);
 
 const input$ = Observable.create(() => {});


### PR DESCRIPTION
<!-- If this is your first PR for redux-observable, please mark these boxes to confirm (otherwise you can exclude them)-->

- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.


# changelog

- change type parameter
  - ofType
  - Epic
  - EpicMiddleware
  - createEpicMiddleware
  - combineEpics
- add test case to typings.ts
