### PR TITLE
chore(deps): remove gitbook-plugin-github from deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,8 +103,5 @@
     "typescript": "^2.1.4",
     "webpack": "^2.2.1",
     "webpack-rxjs-externals": "~1.1.0"
-  },
-  "dependencies": {
-    "gitbook-plugin-github": "^2.0.0"
   }
 }


### PR DESCRIPTION
When you install redux-observable, `gitbook-plugin-github` is being installed to a project which isn't used. `gitbook-plugin-github` is already installed as a `devDependency`.

This pull request fixes this.

