### PR TITLE
Use babel-preset-env instead of es2015

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-    "presets": ["es2015"],
+    "presets": ["env"],
     "plugins": [
       "transform-function-bind",
       "transform-es2015-modules-commonjs",

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -6,7 +6,7 @@ gulp.task('build:esm', () => {
     .pipe(babel({
       babelrc: false,
       presets: [
-        ['es2015', { modules: false }]
+        ['env', { modules: false }]
       ],
       plugins: [
         'transform-function-bind',

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "babel-plugin-transform-function-bind": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-polyfill": "^6.13.0",
-    "babel-preset-es2015": "^6.13.2",
+    "babel-preset-env": "^1.6.1",
     "babel-register": "^6.11.6",
     "chai": "^4.0.1",
     "conventional-changelog-cli": "1.3.3",


### PR DESCRIPTION
`babel-preset-es2015` has been [deprecated](https://babeljs.io/env) in favour of `babel-preset-env` quite a long time ago.

- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.
