### PR TITLE
Automatically narrow Action type in the ofType operator

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -121,53 +121,6 @@ const myEpic = action$ => {
 
 This approach essentially returns an empty `Observable` from the epic, which does not cause any downstream actions.
 
-### Typescript: ofType operator won't narrow to proper Observable type
-
-Let's say you have following action types + action creator types:
-
-```ts
-import { Action } from 'redux'
-
-const enum ActionTypes {
-  One = 'ACTION_ONE',
-  Two = 'ACTION_TWO',
-}
-const doOne = (myStr: string): One => ({ type: ActionTypes.One, myStr })
-const doTwo = (myBool: boolean): Two => ({ type: ActionTypes.Two, myBool })
-
-interface One extends Action {
-  type: ActionTypes.One
-  myStr: string
-}
-interface Two extends Action {
-  type: ActionTypes.Two
-  myBool: boolean
-}
-type Actions = One | Two
-```
-
-When you're using `ofType` operator for filtering, returned observable won't be correctly narrowed within Type System, because its not capable of doing so yet ( TS 2.6.2 ).
-
-To fix this, you need to explicitly set the generic type, so Typescript understands your intent, and narrows your action stream correctly:
-
-```ts
-// This will let action be `Actions` type, which is wrong
-const epic = (action$: ActionsObservable<Actions>) =>
-  action$.pipe(
-    ofType(ActionTypes.One),
-    // action is still type Actions instead of One
-    map((action) => {...})
-  );
-
-// Explicitly set generics fixes the issue
-const epic = (action$: ActionsObservable<Actions>) =>
-  action$.pipe(
-    ofType<One>(ActionTypes.One),
-    // action is correctly narrowed to One
-    map((action) => {...})
-  );
-```
-
 * * *
 
 ## Something else doesn’t work

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ export declare class ActionsObservable<T extends Action> extends Observable<T> {
   constructor(input$: Observable<T>);
   lift<R extends Action>(operator: Operator<T, R>): ActionsObservable<R>;
   lift<R>(operator: Operator<T, R>): Observable<R>;
-  ofType<R extends T = T>(...key: R['type'][]): ActionsObservable<R>;
+  ofType<K extends T['type']>(...key: K[]): ActionsObservable<Extract<T, { type: K }>>;
 }
 
 export declare class StateObservable<S> extends Observable<S> {
@@ -51,4 +51,4 @@ export declare function combineEpics<T extends Action, O extends T = T, S = void
 export declare function combineEpics<E>(...epics: E[]): E;
 export declare function combineEpics(...epics: any[]): any;
 
-export declare function ofType<T extends Action, R extends T = T, K extends R['type'] = R['type']>(...key: K[]): (source: Observable<T>) => Observable<R>;
+export declare function ofType<T extends Action, K extends string>(...key: K[]): (source: Observable<T>) => Observable<Extract<T, { type: K }>>;

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "rimraf": "^2.5.4",
     "rxjs": "^6.0.0",
     "sinon": "^4.5.0",
-    "typescript": "^2.1.4",
+    "typescript": "^2.8.1",
     "webpack": "^4.5.0",
     "webpack-cli": "^2.0.13",
     "webpack-rxjs-externals": "~2.0.0"

--- a/test/typings.ts
+++ b/test/typings.ts
@@ -100,7 +100,7 @@ interface Epic9_Output {
 
 const epic9_1: Epic<FluxStandardAction, Epic9_Output, State, Dependencies> = (action$, state$, dependencies) =>
   action$.pipe(
-    ofType<FluxStandardAction, Epic9_Input>('NINTH'),
+    ofType('NINTH'),
     map(({ type, payload }) => ({
       type: 'ninth' as 'ninth',
       payload: dependencies.func("ninth-" + payload),
@@ -109,7 +109,7 @@ const epic9_1: Epic<FluxStandardAction, Epic9_Output, State, Dependencies> = (ac
 
 const epic9_2 = (action$: ActionsObservable<FluxStandardAction>, state$: StateObservable<void>, dependencies: Dependencies) =>
   action$.pipe(
-    ofType<FluxStandardAction, Epic9_Input>('NINTH'),
+    ofType('NINTH'),
     map(({ type, payload }) => ({
       type: 'ninth',
       payload: dependencies.func("ninth-" + payload),
@@ -229,6 +229,7 @@ const action$3: ActionsObservable<FluxStandardAction> = ActionsObservable.from<F
   const enum ActionTypes {
     One = 'ACTION_ONE',
     Two = 'ACTION_TWO',
+    Three = 'ACTION_THREE'
   }
   const doOne = (myStr: string): One => ({type: ActionTypes.One, myStr})
   const doTwo = (myBool: boolean): Two => ({type: ActionTypes.Two, myBool})
@@ -241,14 +242,26 @@ const action$3: ActionsObservable<FluxStandardAction> = ActionsObservable.from<F
     type: ActionTypes.Two
     myBool: boolean
   }
-  type Actions = One | Two
+  interface Three extends Action {
+    type: ActionTypes.Three,
+    myBool: number;
+  }
+  type Actions = One | Two | Three;
 
-// Explicitly set generics fixes the issue
-const epic = (action$: ActionsObservable<Actions>) =>
+// Automatically narrow action type
+const epicLettable = (action$: ActionsObservable<Actions>) =>
   action$.pipe(
-    ofType<Actions,One>(ActionTypes.One),
+    ofType(ActionTypes.One),
     // action is correctly narrowed to One
     map((action) => { console.log(action.myStr) })
+  );
+
+// Automatically narrows action type in case of multiple actions
+const epicMultipleLettable = (action$: ActionsObservable<Actions>) =>
+  action$.pipe(
+    ofType(ActionTypes.Two, ActionTypes.Three),
+    // action is correctly narrowed to Two | Three
+    map((action) => { console.log(action.myBool) })
   );
 
 }


### PR DESCRIPTION
BREAKING CHANGE: The TypeScript definitions now require TS 2.8+ and `ofType` operations in existing codebases will also stop working (they will fail with a compilation error in case they specified the action type as a generic parameter)

With the new conditional types in TS 2.8 it's now possible to correctly narrow action types in `ofType` (and there are even some nice standard library types to do so).

The only downside of the current implementation is that the lettable version of the operator cannot restrict the the key types to the types used by the actions themselves. Compare the definition of the chained version:

```ts
ofType<K extends T['type']>(...)
```

With the lettable one:

```ts
function ofType<T extends Action, K extends string>(...)
```

Unfortunately in the second case, changing the constraint to `K extends T['type']` breaks the action type inference needed for the automatic narrowing.

As far as I can see this is unavoidable but it doesn't really cause any problems except for slightly worse error messages. If you pass a type that is not compatible with the action:

1. In the chaining case: you get an error telling you that the parameter is not assignable to the action type
2. In the lettable case: the narrowed action type will be `never` so you essentially won't be able to use it for anything useful



- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.
