### PR TITLE
chore(rxjs): Support rxjs v6 UMD builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "description": "RxJS based middleware for Redux. Compose and cancel async actions and more.",
   "module": "lib/esm/index.js",
   "main": "lib/cjs/index.js",
+  "sideEffects": false,
   "scripts": {
     "lint": "eslint src && eslint test",
     "build": "npm run build:esm && npm run build:cjs && npm run build:umd && npm run build:umd:min",
     "build:esm": "gulp build:esm",
     "build:cjs": "babel src -d lib/cjs",
-    "build:umd": "cross-env NODE_ENV=development webpack src/index.js dist/redux-observable.js",
-    "build:umd:min": "cross-env NODE_ENV=production webpack src/index.js dist/redux-observable.min.js",
+    "build:umd": "cross-env NODE_ENV=development webpack src/index.js -o dist/redux-observable.js",
+    "build:umd:min": "cross-env NODE_ENV=production webpack src/index.js -o dist/redux-observable.min.js",
     "build:tests": "rimraf temp && babel test -d temp",
     "clean": "rimraf lib temp dist",
     "check": "npm run lint && npm run test",
@@ -99,7 +100,8 @@
     "rxjs": "^6.0.0-beta.0",
     "sinon": "^2.3.3",
     "typescript": "^2.1.4",
-    "webpack": "^2.2.1",
-    "webpack-rxjs-externals": "~1.1.0"
+    "webpack": "^4.4.1",
+    "webpack-cli": "^2.0.13",
+    "webpack-rxjs-externals": "~2.0.0"
   }
 }

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -4,9 +4,19 @@ import webpackRxjsExternals from 'webpack-rxjs-externals';
 const env = process.env.NODE_ENV;
 
 const config = {
+  mode: env,
   module: {
-    loaders: [
-      { test: /\.js$/, loaders: ['babel-loader'], exclude: /node_modules/ }
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /(node_modules|bower_components)/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: [['es2015', { modules: false }]]
+          }
+        }
+      }
     ]
   },
   output: {
@@ -14,14 +24,16 @@ const config = {
     libraryTarget: 'umd'
   },
   externals: [
-    webpackRxjsExternals(), {
-    redux: {
-      root: 'Redux',
-      commonjs2: 'redux',
-      commonjs: 'redux',
-      amd: 'redux'
+    webpackRxjsExternals(),
+    {
+      redux: {
+        root: 'Redux',
+        commonjs2: 'redux',
+        commonjs: 'redux',
+        amd: 'redux'
+      }
     }
-  }],
+  ],
   plugins: [
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.DefinePlugin({
@@ -29,18 +41,5 @@ const config = {
     })
   ]
 };
-
-if (env === 'production') {
-  config.plugins.push(
-    new webpack.optimize.UglifyJsPlugin({
-      compressor: {
-        pure_getters: true,
-        unsafe: true,
-        unsafe_comps: true,
-        warnings: false
-      }
-    })
-  );
-}
 
 export default config;


### PR DESCRIPTION
This needs https://github.com/jayphelps/webpack-rxjs-externals/pull/8 before it can be merged (build will break because of it) but otherwise I believe is ready and correct.

After this is merged I'll be releasing 1.0.0-alpha of redux-observable, with the plan being that it only supports v6 and v6 style imports. Whether the old compatibility imports work or not is not yet clear as that stuff is still in flux. Latest word is that rxjs-compat might be included by default in v6 with deprecation warnings. If you don't know what any of that is, the tl;dr is that ideally you will use the new rxjs import locations but you might be able to still use the old paths for a time.

This is a follow up to #403