### PR TITLE
chore(publishing): Support dist-tag publishing with our 'shipit' scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "check": "npm run lint && npm run test",
     "test": "npm run lint && npm run build && npm run build:tests && mocha temp && npm run test:typings",
     "test:typings": "tsc --strict index.d.ts test/typings.ts --outDir temp --target ES5 --moduleResolution node --lib dom,es2015 && cd temp && node typings.js",
-    "shipit": "npm run clean && npm run build && npm run lint && npm test && scripts/preprepublish.sh && npm publish",
+    "shipit": "npm run clean && npm run build && npm run lint && npm test && scripts/publish.sh",
     "docs:clean": "rimraf _book",
     "docs:prepare": "gitbook install",
     "docs:build": "npm run docs:prepare && gitbook build -g redux-observable/redux-observable && cp logo/favicon.ico _book/gitbook/images",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -8,17 +8,32 @@ if [[ -z $(git status -uno --porcelain) ]]; then
   vi CHANGELOG.md;
   git diff package.json CHANGELOG.md;
   read -p "Look good? (y/n) " CONDITION;
+
   if [ "$CONDITION" == "y" ]; then
     git add package.json CHANGELOG.md;
     git commit -m "chore(publish): ${VERSION}";
     git tag "${VERSION}";
     git push origin master;
     git push origin "${VERSION}";
+    read -p "Which dist-tag? (latest) " DIST_TAG;
+    DIST_TAG=${DIST_TAG:-latest}
+
+    if [[ $BUMP =~ - && "$DIST_TAG" == "latest"]]; then
+      read -p "Using dist-tag 'latest' for a pre-release. ARE YOU SURE? (y/n) " CONDITION;
+
+      if [ "$CONDITION" == "n" || "$CONDITION" == "" ]; then
+        echo "Cancelled publish by your request!";
+        exit 1;
+      fi
+    fi
+
+    npm publish --tag $DIST_TAG;
   else
     git checkout -f package.json CHANGELOG.md;
     echo "Cancelled publish by your request!";
     exit 1;
   fi
+
 else
   echo "You cannot publish with uncommited changes";
   exit 1;


### PR DESCRIPTION
I correctly published 1.0.0-alpha.0 as the `next` dist-tag but accidentally published alpha.1 as `latest` (the default). I've since corrected this, but hopefully this PR will help prevent that from happening again.