### PR TITLE
fix(deps): gitbook-plugin-github is no longer listed as a normal dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,8 +103,5 @@
     "webpack": "^4.5.0",
     "webpack-cli": "^2.0.13",
     "webpack-rxjs-externals": "~2.0.0"
-  },
-  "dependencies": {
-    "gitbook-plugin-github": "^2.0.0"
   }
 }


### PR DESCRIPTION
it gets added automatically by gitbook sometimes even though it was already listed as a dev-dep. I have never been able to tell when or how, it just shows up as a dep from time to time and I usually manually remove it, but for some reason I committed it last year. I can't recall why I gave in, but it's potentially an unnecessary headache for people who's companies require they audit and approval all dependencies; which is why I classified this as a fix(deps).

https://github.com/redux-observable/redux-observable/commit/cd4463006ae132966ffd9e96aa53bcd32b205724#commitcomment-28489406