### PR TITLE
Combined function name

### DIFF
--- a/src/combineEpics.js
+++ b/src/combineEpics.js
@@ -3,8 +3,8 @@ import { merge } from 'rxjs';
 /**
   Merges all epics into a single one.
  */
-export const combineEpics = (...epics) => (...args) =>
-  merge(
+export const combineEpics = (...epics) => {
+  const merger = (...args) => merge(
     ...epics.map(epic => {
       const output$ = epic(...args);
       if (!output$) {
@@ -13,3 +13,8 @@ export const combineEpics = (...epics) => (...args) =>
       return output$;
     })
   );
+
+  return Object.defineProperty(merger, 'name', {
+    value: `combineEpics(${epics.map(epic => epic.name || '<anonymous>').join(', ')})`,
+  });
+};

--- a/test/combineEpics-spec.js
+++ b/test/combineEpics-spec.js
@@ -71,4 +71,28 @@ describe('combineEpics', () => {
       rootEpic();
     }).to.throw('combineEpics: one of the provided Epics "epic2" does not return a stream. Double check you\'re not missing a return statement!');
   });
+
+  describe('returned epic function name', () => {
+    const epic1 = () => 'named epic';
+    const epic2 = () => 'named epic';
+    const epic3 = () => 'named epic';
+
+    it('should name the new epic with `combineEpics(...epic names)`', () => {
+      const rootEpic = combineEpics(epic1, epic2);
+
+      expect(rootEpic).to.have.property('name').that.equals('combineEpics(epic1, epic2)');
+    });
+
+    it('should annotate combined anonymous epics with `<anonymous>`', () => {
+      const rootEpic = combineEpics(() => 'anonymous', epic2);
+
+      expect(rootEpic).to.have.property('name').that.equals('combineEpics(<anonymous>, epic2)');
+    });
+
+    it('should include all combined epic names in the returned epic', () => {
+      const rootEpic = combineEpics(epic1, epic2, epic3);
+
+      expect(rootEpic).to.have.property('name').that.equals('combineEpics(epic1, epic2, epic3)');
+    });
+  });
 });


### PR DESCRIPTION
Combined functions always return `<anonymous>` which is not very useful. This Commit updates the name of the combined epics to the following:

> combineEpics(epic1, epic2)

<!-- If this is your first PR for redux-observable, please mark these boxes to confirm (otherwise you can exclude them)-->

- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.



