### PR TITLE
Upgrade internal rxjs devdep version to v6-final

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "mocha": "^3.0.1",
     "redux": "^3.5.2",
     "rimraf": "^2.5.4",
-    "rxjs": "^6.0.0-beta.0",
+    "rxjs": "^6.0.0",
     "sinon": "^2.3.3",
     "typescript": "^2.1.4",
     "webpack": "^4.5.0",


### PR DESCRIPTION
Just to make sure we're testing against the latest v6 version and no longer beta/rc/etc

For now we'll leave the peerDep to >=v6-beta.0