### PR TITLE
feat(state$): state$ now only emits subsequent values if the state shallowly is different

### DIFF
--- a/test/StateObservable-spec.js
+++ b/test/StateObservable-spec.js
@@ -1,9 +1,20 @@
-/* globals describe it */
+/* globals describe it beforeEach afterEach */
 import { expect } from 'chai';
+import sinon from 'sinon';
 import { StateObservable } from '../';
 import { Observable, Subject } from 'rxjs';
 
 describe('StateObservable', () => {
+  let spySandbox;
+
+  beforeEach(() => {
+    spySandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    spySandbox.restore();
+  });
+
   it('should exist', () => {
     expect(StateObservable.prototype).to.be.instanceof(Observable);
   });
@@ -33,5 +44,36 @@ describe('StateObservable', () => {
     expect(state$.value).to.equal('first');
     input$.next('second');
     expect(state$.value).to.equal('second');
+  });
+
+  it('should only update when the next value shallowly differs', () => {
+    const input$ = new Subject();
+    const state$ = new StateObservable(input$);
+    const next = spySandbox.spy();
+    state$.subscribe(next);
+
+    expect(state$.value).to.equal(undefined);
+    expect(next.callCount).to.equal(0);
+
+    const first = { value: 'first' };
+    input$.next(first);
+    expect(state$.value).to.equal(first);
+    expect(next.callCount).to.equal(1);
+    expect(next.getCall(0).args).to.deep.equal([first]);
+
+    input$.next(first);
+    expect(state$.value).to.equal(first);
+    expect(next.callCount).to.equal(1);
+
+    first.value = 'something else';
+    input$.next(first);
+    expect(state$.value).to.equal(first);
+    expect(next.callCount).to.equal(1);
+
+    const second = { value: 'second' };
+    input$.next(second);
+    expect(state$.value).to.equal(second);
+    expect(next.callCount).to.equal(2);
+    expect(next.getCall(1).args).to.deep.equal([second]);
   });
 });


### PR DESCRIPTION
(e.g. prevValue !== nextValue) It still emits the current state immediately on subscribe regardless, as it did before, similar to BehaviorSubject. Closes #497
