### PR TITLE
fix(state$): initial state is no longer skipped, and remove deprecated store APIs

### DIFF
--- a/src/StateObservable.js
+++ b/src/StateObservable.js
@@ -1,57 +1,26 @@
 import { Observable, Subject } from 'rxjs';
 
-// Used as a placeholder value so we can tell
-// whether or not the real state has been set,
-// even if the real state was `undefined`
-export const UNSET_STATE_VALUE = {};
-
-// We can't use BehaviorSubject because when we create
-// and give state$ to your epics your reducers have not
-// yet run, so there is no initial state yet until the
-// `@@redux/INIT` action is emitted. BehaviorSubject
-// requires an initial value (which would be undefined)
-// and if an epic subscribes to it on app boot it would
-// synchronously emit that undefined value incorrectly.
-// We could use ReplaySubject to get that behavior, but
-// then it wouldn't have the .value property.
-// We also don't want to expose any Subject to the user at
-// all because then they could do `state$.next()` and
-// screw things up and it would just be a footgun.
-// This also allows us to add a warning message for
-// accessing the state$.value property before redux
-// has initialized.
 export class StateObservable extends Observable {
-  constructor(stateSubject) {
+  constructor(stateSubject, initialState) {
     super(subscriber => {
       const subscription = this.__notifier.subscribe(subscriber);
-      if (this.__value !== UNSET_STATE_VALUE && subscription && !subscription.closed) {
-        subscriber.next(this.__value);
+      if (subscription && !subscription.closed) {
+        subscriber.next(this.value);
       }
       return subscription;
     });
 
-    this.__value = UNSET_STATE_VALUE;
+    this.value = initialState;
     this.__notifier = new Subject();
     this.__subscription = stateSubject.subscribe(value => {
       // We only want to update state$ if it has actually changed since
       // redux requires reducers use immutability patterns.
       // This is basically what distinctUntilChanged() does but it's so simple
       // we don't need to pull that code in
-      if (value !== this.__value) {
-        this.__value = value;
+      if (value !== this.value) {
+        this.value = value;
         this.__notifier.next(value);
       }
     });
-  }
-
-  get value() {
-    if (this.__value === UNSET_STATE_VALUE) {
-      if (process.env.NODE_ENV !== 'production') {
-        require('./utils/console').warn('You accessed state$.value inside one of your Epics, before your reducers have run for the first time, so there is no state yet. You\'ll need to wait until after the first action (@@redux/INIT) is dispatched or by using state$ as an Observable.');
-      }
-      return undefined;
-    } else {
-      return this.__value;
-    }
   }
 }

--- a/src/createEpicMiddleware.js
+++ b/src/createEpicMiddleware.js
@@ -24,9 +24,13 @@ export function createEpicMiddleware(options = defaultOptions) {
   const actionSubject$ = new Subject().pipe(
     observeOn(queueScheduler)
   );
+  const stateSubject$ = new Subject().pipe(
+    observeOn(queueScheduler)
+  );
   const action$ = options.adapter.input(
     new ActionsObservable(actionSubject$)
   );
+  const state$ = new StateObservable(stateSubject$);
   const epic$ = new Subject();
   let store;
 
@@ -36,10 +40,6 @@ export function createEpicMiddleware(options = defaultOptions) {
       require('./utils/console').warn('this middleware is already associated with a store. createEpicMiddleware should be called for every store.\n\nLearn more: https://goo.gl/2GQ7Da');
     }
     store = _store;
-    const stateSubject$ = new Subject().pipe(
-      observeOn(queueScheduler)
-    );
-    const state$ = new StateObservable(stateSubject$, _store);
 
     const result$ = epic$.pipe(
       map(epic => {

--- a/src/createEpicMiddleware.js
+++ b/src/createEpicMiddleware.js
@@ -21,16 +21,6 @@ export function createEpicMiddleware(options = defaultOptions) {
   // inside the options object as well in case they declare only some
   options = { ...defaultOptions, ...options };
 
-  const actionSubject$ = new Subject().pipe(
-    observeOn(queueScheduler)
-  );
-  const stateSubject$ = new Subject().pipe(
-    observeOn(queueScheduler)
-  );
-  const action$ = options.adapter.input(
-    new ActionsObservable(actionSubject$)
-  );
-  const state$ = new StateObservable(stateSubject$);
   const epic$ = new Subject();
   let store;
 
@@ -40,6 +30,16 @@ export function createEpicMiddleware(options = defaultOptions) {
       require('./utils/console').warn('this middleware is already associated with a store. createEpicMiddleware should be called for every store.\n\nLearn more: https://goo.gl/2GQ7Da');
     }
     store = _store;
+    const actionSubject$ = new Subject().pipe(
+      observeOn(queueScheduler)
+    );
+    const stateSubject$ = new Subject().pipe(
+      observeOn(queueScheduler)
+    );
+    const action$ = options.adapter.input(
+      new ActionsObservable(actionSubject$)
+    );
+    const state$ = new StateObservable(stateSubject$, store.getState());
 
     const result$ = epic$.pipe(
       map(epic => {

--- a/test/createEpicMiddleware-spec.js
+++ b/test/createEpicMiddleware-spec.js
@@ -60,25 +60,6 @@ describe('createEpicMiddleware', () => {
     expect(console.warn.getCall(0).args[0]).to.equal('redux-observable | WARNING: this middleware is already associated with a store. createEpicMiddleware should be called for every store.\n\nLearn more: https://goo.gl/2GQ7Da');
   });
 
-  it('should warn about improper use of dispatch function', () => {
-    spySandbox.spy(console, 'warn');
-    const reducer = (state = [], action) => state.concat(action);
-    const epic = (action$, store) => action$.pipe(
-      ofType('PING'),
-      map(() => store.dispatch({ type: 'PONG' })),
-      ignoreElements()
-    );
-
-    const middleware = createEpicMiddleware();
-    const store = createStore(reducer, applyMiddleware(middleware));
-    middleware.run(epic);
-
-    store.dispatch({ type: 'PING' });
-
-    expect(console.warn.callCount).to.equal(1);
-    expect(console.warn.getCall(0).args[0]).to.equal('redux-observable | DEPRECATION: calling store.dispatch() directly in your Epics is deprecated and will be removed. The second argument to your Epic is now a stream of state$ (a StateObservable), instead of the store. Instead of calling store.dispatch() in your Epic, emit actions through the Observable your Epic returns.\n\n  function <T, R, S, D>(action$: ActionsObservable<T>, state$: StateObservable<S>, dependencies?: D): Observable<R>\n\nLearn more: https://redux-observable.js.org/MIGRATION.html');
-  });
-
   it('should update state$ after an action goes through reducers but before epics', () => {
     const actions = [];
     const reducer = (state = 0, action) => {
@@ -218,33 +199,6 @@ describe('createEpicMiddleware', () => {
     }, {
       type: 'PING'
     }]);
-  });
-
-  it('should warn about deprecated use of store.getState()', () => {
-    spySandbox.spy(console, 'warn');
-    const actions = [];
-    const reducer = (state = { foo: 'bar' }, action) => {
-      actions.push(action);
-      return state;
-    };
-    const epic = (action$, state$) =>
-      action$.pipe(
-        ofType('PING'),
-        map(() => ({
-          type: 'RESULT',
-          state: state$.getState()
-        }))
-      );
-
-    const middleware = createEpicMiddleware();
-    const store = createStore(reducer, applyMiddleware(middleware));
-    middleware.run(epic);
-
-    store.dispatch({ type: 'PING' });
-
-    expect(console.warn.callCount).to.equal(1);
-    expect(console.warn.getCall(0).args[0]).to.equal('redux-observable | DEPRECATION: calling store.getState() in your Epics is deprecated and will be removed. The second argument to your Epic is now a stream of state$ (a StateObservable), instead of the store. To imperatively get the current state use state$.value instead of getState(). Alternatively, since it\'s now a stream you can compose and react to state changes.\n\n  function <T, R, S, D>(action$: ActionsObservable<T>, state$: StateObservable<S>, dependencies?: D): Observable<R>\n\nLearn more: https://redux-observable.js.org/MIGRATION.html');
-    expect(actions[actions.length - 1].state).to.equal(store.getState());
   });
 
   it('should accept an epic that wires up action$ input to action$ out', () => {

--- a/test/typings.ts
+++ b/test/typings.ts
@@ -23,12 +23,12 @@ interface Dependencies {
   func(value: string): string;
 }
 
-const epic1: Epic<FluxStandardAction, FluxStandardAction, State> = (action$, store$) =>
+const epic1: Epic<FluxStandardAction, FluxStandardAction, State> = (action$, state$) =>
   action$.pipe(
     ofType('FIRST'),
     map(() => ({
       type: 'first',
-      payload: store$.getState()
+      payload: state$.value
     }))
   );
 
@@ -71,7 +71,7 @@ const epic6: Epic<FluxStandardAction> = action$ =>
     }))
   );
 
-const epic7: Epic<FluxStandardAction, FluxStandardAction, State, Dependencies> = (action$, _, dependencies) =>
+const epic7: Epic<FluxStandardAction, FluxStandardAction, State, Dependencies> = (action$, state$, dependencies) =>
   action$.pipe(
     ofType('SEVENTH'),
     map(({ type, payload }) => ({
@@ -80,7 +80,7 @@ const epic7: Epic<FluxStandardAction, FluxStandardAction, State, Dependencies> =
     }))
   );
 
-const epic8: Epic<FluxStandardAction, FluxStandardAction, State, Dependencies> = (action$, store, dependencies) =>
+const epic8: Epic<FluxStandardAction, FluxStandardAction, State, Dependencies> = (action$, state$, dependencies) =>
   action$.pipe(
     ofType('EIGHTH'),
     map(({ type, payload }) => ({
@@ -98,7 +98,7 @@ interface Epic9_Output {
   payload: string,
 }
 
-const epic9_1: Epic<FluxStandardAction, Epic9_Output, State, Dependencies> = (action$, store, dependencies) =>
+const epic9_1: Epic<FluxStandardAction, Epic9_Output, State, Dependencies> = (action$, state$, dependencies) =>
   action$.pipe(
     ofType<FluxStandardAction, Epic9_Input>('NINTH'),
     map(({ type, payload }) => ({
@@ -107,7 +107,7 @@ const epic9_1: Epic<FluxStandardAction, Epic9_Output, State, Dependencies> = (ac
     }))
   );
 
-const epic9_2 = (action$: ActionsObservable<FluxStandardAction>, store: StateObservable<void>, dependencies: Dependencies) =>
+const epic9_2 = (action$: ActionsObservable<FluxStandardAction>, state$: StateObservable<void>, dependencies: Dependencies) =>
   action$.pipe(
     ofType<FluxStandardAction, Epic9_Input>('NINTH'),
     map(({ type, payload }) => ({
@@ -126,10 +126,10 @@ const epicMiddleware1: EpicMiddleware<FluxStandardAction> = createEpicMiddleware
 const epicMiddleware2 = createEpicMiddleware({ dependencies });
 
 interface CustomEpic<T extends Action, S, U> {
-  (action$: ActionsObservable<T>, store: StateObservable<S>, api: U): Observable<T>;
+  (action$: ActionsObservable<T>, state$: StateObservable<S>, api: U): Observable<T>;
 }
 
-const customEpic: CustomEpic<FluxStandardAction, State, number> = (action$, store, some) =>
+const customEpic: CustomEpic<FluxStandardAction, State, number> = (action$, state$, some) =>
   action$.pipe(
     ofType('CUSTOM1'),
     map(({ type, payload }) => ({
@@ -138,7 +138,7 @@ const customEpic: CustomEpic<FluxStandardAction, State, number> = (action$, stor
     }))
   );
 
-const customEpic2: CustomEpic<FluxStandardAction, State, number> = (action$, store, some) =>
+const customEpic2: CustomEpic<FluxStandardAction, State, number> = (action$, state$, some) =>
   action$.pipe(
     ofType('CUSTOM2'),
     map(({ type, payload }) => ({


### PR DESCRIPTION
I found that state$ was actually skipping the initial first state and in fact because of the way redux v4 works and our new `epicMiddleware.run(rootEpic)` API

BREAKING CHANGE: state$ now receives the initial state

BREAKING CHANGE: previously the second argument to your epics was a "lite" version of the redux store with store.dispatch() and store.getState(), however this has been replaced with a stream of a state$ in v1.0.0 of redux-observable and the old methods were deprecated with warnings in previous alpha versions. This release removes them entirely. See https://redux-observable.js.org/MIGRATION.html