### PR TITLE
feat(rootEpic): an error is now thrown if you provide your root Epic to createEpicMiddleware

### DIFF
--- a/src/createEpicMiddleware.js
+++ b/src/createEpicMiddleware.js
@@ -13,6 +13,10 @@ const defaultOptions = {
 };
 
 export function createEpicMiddleware(options = defaultOptions) {
+  if (process.env.NODE_ENV !== 'production' && typeof options === 'function') {
+    throw new TypeError('Providing your root Epic to `createEpicMiddleware(rootEpic)` is no longer supported, instead use `epicMiddleware.run(rootEpic)`\n\nLearn more: https://redux-observable.js.org/MIGRATION.html#setting-up-the-middleware');
+  }
+
   // even though we used default param, we need to merge the defaults
   // inside the options object as well in case they declare only some
   options = { ...defaultOptions, ...options };

--- a/test/createEpicMiddleware-spec.js
+++ b/test/createEpicMiddleware-spec.js
@@ -36,6 +36,12 @@ describe('createEpicMiddleware', () => {
     store.dispatch({ type: 'FIRST_ACTION_TO_TRIGGER_MIDDLEWARE' });
   });
 
+  it('should throw an error if you provide a function to createEpicMiddleware (used to be rootEpic)', () => {
+    expect(() => {
+      createEpicMiddleware(() => {});
+    }).to.throw(TypeError, 'Providing your root Epic to `createEpicMiddleware(rootEpic)` is no longer supported, instead use `epicMiddleware.run(rootEpic)`\n\nLearn more: https://redux-observable.js.org/MIGRATION.html#setting-up-the-middleware');
+  });
+
   it('should warn about reusing the epicMiddleware', () => {
     spySandbox.spy(console, 'warn');
     const reducer = (state = [], action) => state.concat(action);
@@ -357,7 +363,7 @@ describe('createEpicMiddleware', () => {
     // HostReportErrors e.g. window.onerror or process.on('uncaughtException')
     expect(() => {
       store.dispatch({ type: 'FIRE_1' });
-    }).to.not.throw('some error');
+    }).to.not.throw();
   });
 
   it('should throw if you provide a root epic that doesn\'t return anything', (done) => {


### PR DESCRIPTION
See https://redux-observable.js.org/MIGRATION.html#setting-up-the-middleware

This should help people who happen to not read the migration guide or release notes.