### PR TITLE
fix(combineEpics): combineEpics no longer errors on React Native Android because of readonly `name`  prop setting

### DIFF
--- a/src/combineEpics.js
+++ b/src/combineEpics.js
@@ -14,7 +14,14 @@ export const combineEpics = (...epics) => {
     })
   );
 
-  return Object.defineProperty(merger, 'name', {
-    value: `combineEpics(${epics.map(epic => epic.name || '<anonymous>').join(', ')})`,
-  });
+  // Technically the `name` property on Function's are supposed to be read-only.
+  // While some JS runtimes allow it anyway (so this is useful in debugging)
+  // some actually throw an exception when you attempt to do so.
+  try {
+    Object.defineProperty(merger, 'name', {
+      value: `combineEpics(${epics.map(epic => epic.name || '<anonymous>').join(', ')})`,
+    });
+  } catch (e) {}
+
+  return merger;
 };


### PR DESCRIPTION
Reported by someone on Discord, relayed by @evertbouw. On React Native Android it appears the JS runtime enforces the fact that Functions are supposed to have their `name` property be readonly, by throwing an exception. So in those cases we just catch the error and ignore it since I'm not aware of any other way to test whether it's supported or not. I'm also not sure how we could unit test this behavior either.

![image](https://user-images.githubusercontent.com/762949/40938458-ee36bcb2-680f-11e8-981e-dd25f15d77b1.png)
