### PR TITLE
chore(babel): remove unnecessary transform-es2015-modules-commonjs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,6 @@
 {
     "presets": ["env"],
     "plugins": [
-      "transform-es2015-modules-commonjs",
       "transform-object-rest-spread"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "babel-core": "^6.26.0",
     "babel-eslint": "^7.0.0",
     "babel-loader": "^7.0.0",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.11.5",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-polyfill": "^6.13.0",
     "babel-preset-env": "^1.6.1",


### PR DESCRIPTION
AFAICT it's not needed for us anymore. ~I believe~ I thought this is what is causing #513 to fail with the new webpack but turns out it's not. Regardless something to do.