### PR TITLE
fix(errors): errors from reducers are no longer caught and logged, instead are rethrown

### DIFF
--- a/src/createEpicMiddleware.js
+++ b/src/createEpicMiddleware.js
@@ -53,13 +53,7 @@ export function createEpicMiddleware(rootEpic, options = defaultOptions) {
           return output$;
         })
         ::switchMap(output$ => options.adapter.output(output$))
-        .subscribe(action => {
-          try {
-            store.dispatch(action);
-          } catch (err) {
-            console.error(err);
-          }
-        });
+        .subscribe(store.dispatch);
 
       // Setup initial root epic
       epic$.next(rootEpic);

--- a/test/createEpicMiddleware-spec.js
+++ b/test/createEpicMiddleware-spec.js
@@ -70,13 +70,11 @@ describe('createEpicMiddleware', () => {
     ]);
   });
 
-  it('should console error when reducer throw exception', () => {
-    sinon.spy(console, 'error');
-
+  it('should rethrow errors when a reducer throws an exception', () => {
     const reducer = (state = [], action) => {
       switch (action.type) {
         case 'ACTION_1':
-          throw new Error();
+          throw new Error('bad stuff');
         default:
           return state;
       }
@@ -89,9 +87,9 @@ describe('createEpicMiddleware', () => {
     const middleware = createEpicMiddleware(epic);
     const store = createStore(reducer, applyMiddleware(middleware));
 
-    store.dispatch({ type: 'FIRE_1' });
-    expect(console.error.callCount).to.equal(1);
-    console.error.restore();
+    expect(() => {
+      store.dispatch({ type: 'FIRE_1' });
+    }).to.throw(Error, 'bad stuff');
   });
 
   it("should throw if you don't provide a rootEpic", () => {


### PR DESCRIPTION
This PR is against the `stable` branch (tracking 0.18.0), not `master` (tracking 1.0.0-beta.1). It is not applicable to master, so it does not need to be ported.

***

related #263#issuecomment-395109222

BREAKING CHANGE: For 0.19.0 errors from reducers are no longer caught and console.error logged, instead they are just rethrown as before. This was a temporary workaround for a bug in rxjs where it would silently swallow errors. That bug has been fixed in 5.5.6+, so it is highly recommended you use _at least_ rxjs@5.5.6+ with this version of redux-observable. However, redux-observable is close to reaching 1.0.0-final which will require rxjs v6 and redux v4, if you'd like to start upgrading to it now you can use redux-observable@next (as of this writing 1.0.0-beta.1)

I thought about bumping the peer dep to rxjs@5.5.6 but figured it might be overkill since it still works with previous versions, it just runs the risk of potentially swallowing errors. Does anyone think we _should_ bump the peer dep to restrict it?

Cc/ @anton164 