### PR TITLE
fix(typings): Epic type parameter for State (third type param) now defaults to any instead of void

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,8 +33,8 @@ export declare class StateObservable<S> extends Observable<S> {
   value: S
 }
 
-export declare interface Epic<T extends Action, O extends T = T, S = void, D = any> {
-  (action$: ActionsObservable<T>, state$: StateObservable<S>, dependencies: D): Observable<O>;
+export declare interface Epic<Input extends Action = any, Output extends Input = Input, State = any, Dependencies = any> {
+  (action$: ActionsObservable<Input>, state$: StateObservable<State>, dependencies: Dependencies): Observable<Output>;
 }
 
 export interface EpicMiddleware<T extends Action, O extends T = T, S = void, D = any> extends Middleware {


### PR DESCRIPTION
Defaulting to void IMO doesn't make sense because why would someone use redux if they don't have any state at all. Instead, a default of `any` means they can choose to live wild if they'd rather not type their store's state.

I also renamed the type param names so that they're more friendly in IDEs since having four type params with single letters is confusing otherwise.