### PR TITLE
docs(Epics.md) Fix typo

### DIFF
--- a/docs/basics/Epics.md
+++ b/docs/basics/Epics.md
@@ -169,7 +169,7 @@ const users = (state = {}, action) => {
 Your Epics receive a second argument, a stream of store states.
 
 ```js
-function (action$: ActionsObservable<Action>, state$: StateOverable<State>): ActionsObservable<Action>;
+function (action$: ActionsObservable<Action>, state$: StateObservable<State>): ActionsObservable<Action>;
 ```
 
 With this, you can use `state$.value` to synchronously access the current state:


### PR DESCRIPTION
<!-- If this is your first PR for redux-observable, please mark these boxes to confirm (otherwise you can exclude them)-->

Fixes typo: `StateOverable` -> `StateObservable`.

- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.
