### PR TITLE
feat(StateObservable): Add getState method to StateObservable

### DIFF
--- a/src/StateObservable.js
+++ b/src/StateObservable.js
@@ -23,4 +23,11 @@ export class StateObservable extends Observable {
       }
     });
   }
+
+  getState() {
+    if (process.env.NODE_ENV !== 'production') {
+      require('./utils/console').warn('Deprecated Usage of getState Found.');
+    }
+    return this.value;
+  }
 }


### PR DESCRIPTION
This would be extremely helpful when migrating to the latest versions of redux-observable. We are in a weird spot where our application relies on RxJS 6, but previously only supported redux-observable@0.x. I understand if this is philosophically against what you'd like for the library, but I thought it might be helpful for other just so that they can migrate incrementally. Maybe a 1.0.0-compat version? Please let me know if there's anything else I can do/provide in the meantime.

<!-- If this is your first PR for redux-observable, please mark these boxes to confirm (otherwise you can exclude them)-->

- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.
