### PR TITLE
Change Epic typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,21 +33,21 @@ export declare class StateObservable<S> extends Observable<S> {
   value: S
 }
 
-export declare interface Epic<Input extends Action = any, Output extends Input = Input, State = any, Dependencies = any> {
+export declare interface Epic<Input extends Action = any, Output extends Action = Input, State = any, Dependencies = any> {
   (action$: ActionsObservable<Input>, state$: StateObservable<State>, dependencies: Dependencies): Observable<Output>;
 }
 
-export interface EpicMiddleware<T extends Action, O extends T = T, S = void, D = any> extends Middleware {
-  run(rootEpic: Epic<T, O, S, D>): void;
+export interface EpicMiddleware<I extends Action, O extends Action = I, S = void, D = any> extends Middleware {
+  run(rootEpic: Epic<I, O, S, D>): void;
 }
 
 interface Options<D = any> {
   dependencies?: D;
 }
 
-export declare function createEpicMiddleware<T extends Action, O extends T = T, S = void, D = any>(options?: Options<D>): EpicMiddleware<T, O, S, D>;
+export declare function createEpicMiddleware<I extends Action, O extends Action = I, S = void, D = any>(options?: Options<D>): EpicMiddleware<I, O, S, D>;
 
-export declare function combineEpics<T extends Action, O extends T = T, S = void, D = any>(...epics: Epic<T, O, S, D>[]): Epic<T, O, S, D>;
+export declare function combineEpics<I extends Action, O extends Action = I, S = void, D = any>(...epics: Epic<I, O, S, D>[]): Epic<I, O, S, D>;
 export declare function combineEpics<E>(...epics: E[]): E;
 export declare function combineEpics(...epics: any[]): any;
 


### PR DESCRIPTION
As far as I understood, there is no reason to limit the Output type of the Epic to extend the Input type, because they can have completely different types.

Fixes #560 

- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.
