### PR TITLE
feat(createEpicMiddleware): inject the action & state in each dependency

### DIFF
--- a/src/createEpicMiddleware.js
+++ b/src/createEpicMiddleware.js
@@ -28,6 +28,21 @@ export function createEpicMiddleware(options = {}) {
 
     const result$ = epic$.pipe(
       map(epic => {
+        // Interate over the dependencies and pass the action and the state to
+        // each function
+        for (const dependency in options.dependencies) {
+          if (options.dependencies.hasOwnProperty(dependency)) {
+            const dependencyValue = options.dependencies[dependency];
+
+            // Alter the dependency only if it's a function
+            if (typeof dependencyValue === 'function') {
+              // Pass the action and the state to the function
+              options.dependencies[dependency] = () =>
+                dependencyValue(action$, state$);
+            }
+          }
+        }
+
         const output$ = 'dependencies' in options
           ? epic(action$, state$, options.dependencies)
           : epic(action$, state$);


### PR DESCRIPTION
<!-- If this is your first PR for redux-observable, please mark these boxes to confirm (otherwise you can exclude them)-->

- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.

I have a use case where I need to conditionally add an HTTP header to each request based on a value in my Redux store. To solve this problem I discovered `dependencies` which I can pass to `createEpicMiddleware` and access in each epic. So I thought maybe I'd pass the following `dependencies`:
```js
{
    get: ajax.getJSON
}
```

But then I realized that I'd still have to manually (check & )pass the header to the function, so that didn't solve it.

My addition iterates over the passed `dependencies`, check whether each is a function, and if so it wraps it in a function that passes it the `state$` and the `action$` (which I don't need for my use-case but might as well pass it (or not?)).

If there's any other solution for my use case that doesn't require this change please let me know, it would be much appreciated.

**Edit:** Not sure why but the `npm run build` doesn't pass, even without the changes.