### PR TITLE
chore(webpack): update webpack, and fix babel-loader preset to be env

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,8 +99,8 @@
     "rxjs": "^6.0.0",
     "sinon": "^4.5.0",
     "typescript": "^2.1.4",
-    "webpack": "^4.5.0",
-    "webpack-cli": "^2.0.13",
+    "webpack": "^4.29.3",
+    "webpack-cli": "^3.2.3",
     "webpack-rxjs-externals": "~2.0.0"
   }
 }

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -13,7 +13,7 @@ const config = {
         use: {
           loader: 'babel-loader',
           options: {
-            presets: [['es2015', { modules: false }]]
+            presets: [['env', { modules: false }]]
           }
         }
       }


### PR DESCRIPTION
This should get our tests back to green.

--

For those interested in digging, our tests were broken because of a change in webpack-cli, just had to upgrade: https://github.com/webpack/webpack-cli/issues/607