### PR TITLE
chore(examples): Refactor navigation tests

### DIFF
--- a/examples/navigation/src/epics/adminAccess.test.js
+++ b/examples/navigation/src/epics/adminAccess.test.js
@@ -3,25 +3,20 @@ import { TestScheduler } from 'rxjs/testing'
 import { accessDenied, CHECKED_ADMIN_ACCESS } from '../actions'
 import adminAccessEpic from './adminAccess'
 
-describe('adminAccess epic', () => {
-  describe('when admin access is checked', () => {
-    it('creates actions to deny access and redirect back home', () => {
-      const testScheduler = new TestScheduler((actual, expected) => {
-        expect(actual).toEqual(expected)
-      })
+test('checking admin access', () => {
+  const testScheduler = new TestScheduler((actual, expected) => {
+    expect(actual).toEqual(expected)
+  })
 
-      testScheduler.run(({ hot, expectObservable }) => {
-        const action$ = hot('-a', {
-          a: { type: CHECKED_ADMIN_ACCESS }
-        })
-        const state$ = null
-        const output$ = adminAccessEpic(action$, state$)
+  testScheduler.run(({ hot, expectObservable }) => {
+    const action$ = hot('-a', {
+      a: { type: CHECKED_ADMIN_ACCESS }
+    })
+    const output$ = adminAccessEpic(action$)
 
-        expectObservable(output$).toBe('- 2000ms a 1999ms b -', {
-          a: accessDenied(),
-          b: push('/')
-        })
-      })
+    expectObservable(output$).toBe('- 2000ms a 1999ms b -', {
+      a: accessDenied(),
+      b: push('/')
     })
   })
 })

--- a/examples/navigation/src/epics/clearSearchResults.test.js
+++ b/examples/navigation/src/epics/clearSearchResults.test.js
@@ -2,42 +2,36 @@ import { TestScheduler } from 'rxjs/testing'
 import { clearSearchResults, searchUsers } from '../actions'
 import clearSearchResultsEpic from './clearSearchResults'
 
-describe('clearSearchResults epic', () => {
-  describe('when a search query is empty', () => {
-    it('creates an action to clear the search results', () => {
-      const testScheduler = new TestScheduler((actual, expected) => {
-        expect(actual).toEqual(expected)
-      })
-
-      testScheduler.run(({ hot, expectObservable }) => {
-        const action$ = hot('-a', {
-          a: searchUsers()
-        })
-        const state$ = null
-        const output$ = clearSearchResultsEpic(action$, state$)
-
-        expectObservable(output$).toBe('-a', {
-          a: clearSearchResults()
-        })
-      })
-    })
+test('non-empty search query', () => {
+  const testScheduler = new TestScheduler((actual, expected) => {
+    expect(actual).toEqual(expected)
   })
 
-  describe('when a search query is not empty', () => {
-    it('does nothing', () => {
-      const testScheduler = new TestScheduler((actual, expected) => {
-        expect(actual).toEqual(expected)
-      })
+  testScheduler.run(({ hot, expectObservable }) => {
+    const action$ = hot('-a', {
+      a: searchUsers('jayphelps')
+    })
 
-      testScheduler.run(({ hot, expectObservable }) => {
-        const action$ = hot('-a', {
-          a: searchUsers('jayphelps')
-        })
-        const state$ = null
-        const output$ = clearSearchResultsEpic(action$, state$)
+    const output$ = clearSearchResultsEpic(action$)
 
-        expectObservable(output$).toBe('--')
-      })
+    expectObservable(output$).toBe('--')
+  })
+})
+
+test('empty search query', () => {
+  const testScheduler = new TestScheduler((actual, expected) => {
+    expect(actual).toEqual(expected)
+  })
+
+  testScheduler.run(({ hot, expectObservable }) => {
+    const action$ = hot('-a', {
+      a: searchUsers()
+    })
+
+    const output$ = clearSearchResultsEpic(action$)
+
+    expectObservable(output$).toBe('-a', {
+      a: clearSearchResults()
     })
   })
 })

--- a/examples/navigation/src/epics/fetchReposByUser.test.js
+++ b/examples/navigation/src/epics/fetchReposByUser.test.js
@@ -5,33 +5,29 @@ import fetchReposByUserEpic from './fetchReposByUser'
 
 jest.mock('rxjs/ajax')
 
-describe('fetchReposByUser epic', () => {
-  describe('when user repos are requested', () => {
-    it('creates an action to receive user repos', () => {
-      const user = 'tanem'
-      const repos = [{ id: 1, name: 'a' }, { id: 2, name: 'b' }]
+const user = 'tanem'
+const repos = [{ id: 1, name: 'a' }, { id: 2, name: 'b' }]
 
-      const testScheduler = new TestScheduler((actual, expected) => {
-        expect(actual).toEqual(expected)
+test('fetching user repos', () => {
+  const testScheduler = new TestScheduler((actual, expected) => {
+    expect(actual).toEqual(expected)
+  })
+
+  testScheduler.run(({ hot, cold, expectObservable }) => {
+    const action$ = hot('-a', {
+      a: requestReposByUser('tanem')
+    })
+
+    ajax.getJSON.mockImplementation(() =>
+      cold('--a', {
+        a: repos
       })
+    )
 
-      testScheduler.run(({ hot, cold, expectObservable }) => {
-        const action$ = hot('-a', {
-          a: requestReposByUser('tanem')
-        })
-        const state$ = null
-        ajax.getJSON.mockImplementation(() =>
-          cold('--a', {
-            a: repos
-          })
-        )
+    const output$ = fetchReposByUserEpic(action$)
 
-        const output$ = fetchReposByUserEpic(action$, state$)
-
-        expectObservable(output$).toBe('---a', {
-          a: receiveUserRepos(user, repos)
-        })
-      })
+    expectObservable(output$).toBe('---a', {
+      a: receiveUserRepos(user, repos)
     })
   })
 })

--- a/examples/navigation/src/epics/searchUsers.test.js
+++ b/examples/navigation/src/epics/searchUsers.test.js
@@ -1,0 +1,118 @@
+import { replace } from 'react-router-redux'
+import { ajax } from 'rxjs/ajax'
+import { TestScheduler } from 'rxjs/testing'
+import { clearSearchResults, receiveUsers, searchUsers } from '../actions'
+import searchUsersEpic from './searchUsers'
+
+jest.mock('rxjs/ajax')
+
+const user = 'tanem'
+const users = {
+  total_count: 2,
+  incomplete_results: false,
+  items: [
+    {
+      login: 'tanem',
+      id: 464864
+    },
+    {
+      login: 'tanema',
+      id: 463193
+    }
+  ]
+}
+
+afterEach(() => {
+  ajax.getJSON.mockReset()
+})
+
+test('empty search query', () => {
+  const testScheduler = new TestScheduler((actual, expected) => {
+    expect(ajax.getJSON).not.toHaveBeenCalled()
+    expect(actual).toEqual(expected)
+  })
+
+  testScheduler.run(({ hot, expectObservable }) => {
+    const action$ = hot('-a', {
+      a: searchUsers()
+    })
+
+    const output$ = searchUsersEpic(action$)
+
+    expectObservable(output$).toBe('-')
+  })
+})
+
+test('non-empty search query', () => {
+  const testScheduler = new TestScheduler((actual, expected) => {
+    expect(ajax.getJSON).toHaveBeenCalledTimes(1)
+    expect(actual).toEqual(expected)
+  })
+
+  testScheduler.run(({ hot, cold, expectObservable }) => {
+    const action$ = hot('-a', {
+      a: searchUsers(user)
+    })
+
+    ajax.getJSON.mockImplementation(() =>
+      cold('-u', {
+        u: users
+      })
+    )
+
+    const output$ = searchUsersEpic(action$)
+
+    expectObservable(output$).toBe('- 800ms a b', {
+      a: replace(`?q=${user}`),
+      b: receiveUsers(users.items)
+    })
+  })
+})
+
+test('frequent non-empty search queries', () => {
+  const testScheduler = new TestScheduler((actual, expected) => {
+    expect(ajax.getJSON).toHaveBeenCalledTimes(1)
+    expect(actual).toEqual(expected)
+  })
+
+  testScheduler.run(({ hot, cold, expectObservable }) => {
+    const action$ = hot('-a-b-c-d-e', {
+      a: searchUsers('t'),
+      b: searchUsers('ta'),
+      c: searchUsers('tan'),
+      d: searchUsers('tane'),
+      e: searchUsers('tanem')
+    })
+
+    ajax.getJSON.mockImplementation(() =>
+      cold('-u', {
+        u: users
+      })
+    )
+
+    const output$ = searchUsersEpic(action$)
+
+    expectObservable(output$).toBe('- 808ms a b', {
+      a: replace(`?q=${user}`),
+      b: receiveUsers(users.items)
+    })
+  })
+})
+
+test('clearing search results', () => {
+  const testScheduler = new TestScheduler((actual, expected) => {
+    expect(ajax.getJSON).not.toHaveBeenCalled()
+    expect(actual).toEqual(expected)
+  })
+
+  testScheduler.run(({ hot, expectObservable }) => {
+    const action$ = hot('-a 799ms b', {
+      a: searchUsers(user),
+      b: clearSearchResults()
+    })
+
+    const output$ = searchUsersEpic(action$)
+
+    expectObservable(output$).toBe('-')
+  })
+})


### PR DESCRIPTION
Builds on the work already done in #610:

- Adds searchUsers epic test.
- Refactors existing tests to reduce nesting.