### PR TITLE
feat(createEpicMiddleware): Add createEpicMiddleware option gatekeep to swallow/emit actions only from epics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ temp
 dist
 _book
 typings
+.idea
+yarn.lock

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,6 +43,7 @@ export interface EpicMiddleware<T extends Action, O extends T = T, S = void, D =
 
 interface Options<D = any> {
   dependencies?: D;
+  gatekeep?: boolean;
 }
 
 export declare function createEpicMiddleware<T extends Action, O extends T = T, S = void, D = any>(options?: Options<D>): EpicMiddleware<T, O, S, D>;


### PR DESCRIPTION
Fixes #626 

Adds the `createEpicMiddleware` option `gatekeep`, which forces actions through the current epic before hitting subsequent middleware and the reducers. Only actions produced by the epics will be passed through and processed accordingly. Any actions not produced by epics are effectively swallowed.

<!-- If this is your first PR for redux-observable, please mark these boxes to confirm (otherwise you can exclude them)-->

- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.
