### PR TITLE
Feature proposal: createDependencies option for createEpicMiddleware

### DIFF
--- a/docs/api/createEpicMiddleware.md
+++ b/docs/api/createEpicMiddleware.md
@@ -16,7 +16,7 @@
 ### redux/configureStore.js
 
 ```js
-import { createStore, applyMiddleware, compose } from 'redux';
+import { createStore, applyMiddleware } from 'redux';
 import { createEpicMiddleware } from 'redux-observable';
 import { rootEpic, rootReducer } from './modules/root';
 

--- a/docs/api/createEpicMiddleware.md
+++ b/docs/api/createEpicMiddleware.md
@@ -5,7 +5,8 @@
 #### Arguments
 
 1. *`[options: Object]`*: The optional configuration. Options:
-    * *`dependencies`*: If given, it will be injected as the 3rd argument to all epics.
+    * *`createDependencies`*: A functions that takes the state observable as the only parameter, and returns any object that will be injected as the 3rd argument to all epics. May not be used in conjunction with `dependencies`.
+    * *`dependencies`*: If given, it will be injected as the 3rd argument to all epics. May not be used in conjunction with `createDependencies`.
 
 #### Returns
 
@@ -69,6 +70,59 @@ export const rootEpic = (action$, state$, { ping, pong }) =>
   action$.pipe(
     filter(action => action.type === ping()),
     mapTo({ type: pong() })
+  )
+```
+
+#### Example with createDependencies
+
+### redux/configureStore.js
+
+```js
+import { createStore, applyMiddleware } from 'redux';
+import { createEpicMiddleware } from 'redux-observable';
+import { ajax } from 'rxjs/ajax';
+import { rootEpic, rootReducer } from './modules/root';
+
+const epicMiddleware = createEpicMiddleware({
+  createDependencies: state$ => ({
+    request: (path) => ajax({
+      url: `http://example.com/${path}`,
+      headers: {
+        Authorization: `Bearer ${state$.value.auth.token}`
+      }
+    })
+  })
+});
+
+export default function configureStore() {
+  const store = createStore(
+    rootReducer,
+    applyMiddleware(epicMiddleware)
+  );
+
+  epicMiddleware.run(rootEpic);
+
+  return store;
+}
+```
+
+### redux/modules/root.js
+
+```js
+export const rootEpic = (action$, state$, { request }) => 
+  action$.pipe(
+    filter(action => action.type === 'PING'),
+    mergeMap(() =>
+      request('pong').pipe(
+        map(({ response }) => ({
+          type: 'PONG',
+          payload: response
+        })),
+        catchError(error => {
+          /* handle error */
+        })
+      ) 
+    ),
   )
 ```
 

--- a/docs/api/createEpicMiddleware.md
+++ b/docs/api/createEpicMiddleware.md
@@ -11,7 +11,7 @@
 
 (*`MiddlewareAPI`*): An instance of the redux-observable middleware.
 
-#### Example
+#### Example without dependencies
 
 ### redux/configureStore.js
 
@@ -33,3 +33,42 @@ export default function configureStore() {
   return store;
 }
 ```
+
+#### Example with dependencies
+
+### redux/configureStore.js
+
+```js
+import { createStore, applyMiddleware } from 'redux';
+import { createEpicMiddleware } from 'redux-observable';
+import { rootEpic, rootReducer } from './modules/root';
+
+const epicMiddleware = createEpicMiddleware({
+  dependencies: {
+    ping: () => "PING",
+    pong: () => "PONG"
+  }
+});
+
+export default function configureStore() {
+  const store = createStore(
+    rootReducer,
+    applyMiddleware(epicMiddleware)
+  );
+
+  epicMiddleware.run(rootEpic);
+
+  return store;
+}
+```
+
+### redux/modules/root.js
+
+```js
+export const rootEpic = (action$, state$, { ping, pong }) => 
+  action$.pipe(
+    filter(action => action.type === ping()),
+    mapTo({ type: pong() })
+  )
+```
+

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,11 +41,12 @@ export interface EpicMiddleware<T extends Action, O extends T = T, S = void, D =
   run(rootEpic: Epic<T, O, S, D>): void;
 }
 
-interface Options<D = any> {
+interface Options<D = any, State = void> {
+  createDependencies?: (state$: StateObservable<State>) => D;
   dependencies?: D;
 }
 
-export declare function createEpicMiddleware<T extends Action, O extends T = T, S = void, D = any>(options?: Options<D>): EpicMiddleware<T, O, S, D>;
+export declare function createEpicMiddleware<T extends Action, O extends T = T, S = void, D = any>(options?: Options<D, S>): EpicMiddleware<T, O, S, D>;
 
 export declare function combineEpics<T extends Action, O extends T = T, S = void, D = any>(...epics: Epic<T, O, S, D>[]): Epic<T, O, S, D>;
 export declare function combineEpics<E>(...epics: E[]): E;

--- a/test/createEpicMiddleware-spec.js
+++ b/test/createEpicMiddleware-spec.js
@@ -415,6 +415,23 @@ describe('createEpicMiddleware', () => {
     expect(epic.called).to.equal(true);
   });
 
+  it('should pass state$ to dependencies when using createDependencies', () => {
+    const reducer = (state = 'INITIAL_STATE', action) => state;
+    const epic = spySandbox.spy(action$ => action$);
+
+    const middleware = createEpicMiddleware({
+      createDependencies: state$ => ({
+        myDep: () => state$.value
+      }),
+    });
+    createStore(reducer, applyMiddleware(middleware));
+    middleware.run(epic);
+
+    expect(epic.firstCall.args.length).to.deep.equal(3);
+    expect(epic.firstCall.args[2]).to.haveOwnProperty('myDep');
+    expect(epic.firstCall.args[2].myDep()).to.deep.equal('INITIAL_STATE');
+  });
+
   it('should not allow interference from the public queueScheduler singleton', (done) => {
     const reducer = (state = [], action) => state.concat(action);
     const epic1 = action$ =>


### PR DESCRIPTION
- [X] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [X] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.

Hello!

When developing with `redux-observable`, we end up repeating the common pattern of passing `state$` to any dependency. For example, we have a `request` dependency which is a wrapper around `rxjs/ajax`. We pass `state$` to that function on every single call so that it can take the API token from the state and update the request headers accordingly.

My proposition is to introduce an option for `createEpicMiddleware` called `createDependencies` which must be a function that accepts the `state$` and returns the actual dependencies (the same dependencies that you'd pass to the `dependencies` option). This would avoid repeating code, as we wouldn't need manually to pass the `state$` to every single dependency.

If you like this change and will consider merging it, I suggest that we discuss whether or not `action$` should be passed too. I believe that it shouldn't, because I can't find any use cases for it, and might enable some anti-patterns. However, if there are legitimate use cases for it, implementing it in the future would break backward compatibility. So I think that this is an important discussion to have.

By the way, I regret that I committed these changes before realizing that #598 exists. I tried to search for this exact feature but couldn't find it. In [this comment](https://github.com/redux-observable/redux-observable/pull/598#issuecomment-453654980) you mention an alternative, but I think that the code example is hard to understand and honestly it feels a bit "hacky". I haven't tried it, but in TypeScript, it seems to me that we'd have to either use `any` or define some complex types.

If you need some examples of use cases, you can take a look at the commit f4dd2e042c1dcd579b738484d9f7d358bef782a5.

Thanks for your attention.