### PR TITLE
chore(gulp): update gulp to 4.0 to fix build

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -2,7 +2,7 @@ import gulp from 'gulp';
 import babel from 'gulp-babel';
 
 gulp.task('build:esm', () => {
-  gulp.src('src/**/*.js')
+  return gulp.src('src/**/*.js')
     .pipe(babel({
       babelrc: false,
       presets: [

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "gitbook-plugin-github": "^2.0.0",
     "gitbook-plugin-prism": "^2.0.1",
     "gitbook-plugin-theme-default": "^1.0.5",
-    "gulp": "^3.9.1",
+    "gulp": "^4.0.1",
     "gulp-babel": "^6.1.2",
     "json-server": "^0.10.0",
     "mocha": "^3.5.3",


### PR DESCRIPTION
Older versions of gulp used a now deprecated npm package called [natives](npmjs.com/package/natives) which did naughty things and broke our build in newer Node.

https://travis-ci.org/redux-observable/redux-observable/jobs/524268610