### PR TITLE
Added improved method of logging errors

### DIFF
--- a/src/combineEpics.js
+++ b/src/combineEpics.js
@@ -15,12 +15,14 @@ export const combineEpics = (...epics) => {
         output$.pipe
           ? output$.pipe(
             catchError(error => {
-              console.error(
-                epic.name,
-                error.constructor.name === 'ErrorEvent'
-                  ? error.error.stack
-                  : error
-              );
+              if (console.error) {
+                console.error(
+                  epic.name,
+                  error.constructor.name === 'ErrorEvent'
+                    ? error.error.stack
+                    : error
+                );
+              }
 
               throw error;
             })

--- a/src/combineEpics.js
+++ b/src/combineEpics.js
@@ -1,3 +1,4 @@
+import { catchError } from 'rxjs/operators';
 import { merge } from 'rxjs';
 
 /**
@@ -10,7 +11,18 @@ export const combineEpics = (...epics) => {
       if (!output$) {
         throw new TypeError(`combineEpics: one of the provided Epics "${epic.name || '<anonymous>'}" does not return a stream. Double check you\'re not missing a return statement!`);
       }
-      return output$;
+      return output$.pipe(
+        catchError(error => {
+          console.error(
+            epic.name,
+            error.constructor.name === 'ErrorEvent'
+            ? error.error.stack
+            : error
+          )
+          
+          throw error;
+        })
+      );
     })
   );
 

--- a/src/combineEpics.js
+++ b/src/combineEpics.js
@@ -12,7 +12,7 @@ export const combineEpics = (...epics) => {
         throw new TypeError(`combineEpics: one of the provided Epics "${epic.name || '<anonymous>'}" does not return a stream. Double check you\'re not missing a return statement!`);
       }
       return (
-        output$.pipe
+        process.env.NODE_ENV !== 'production' && output$.pipe
           ? output$.pipe(
             catchError(error => {
               if (console.error) {

--- a/src/combineEpics.js
+++ b/src/combineEpics.js
@@ -18,7 +18,7 @@ export const combineEpics = (...epics) => {
               if (console.error) {
                 console.error(
                   epic.name,
-                  error.constructor.name === 'ErrorEvent'
+                  error && error.constructor && error.constructor.name === 'ErrorEvent'
                     ? error.error.stack
                     : error
                 );

--- a/src/combineEpics.js
+++ b/src/combineEpics.js
@@ -11,17 +11,21 @@ export const combineEpics = (...epics) => {
       if (!output$) {
         throw new TypeError(`combineEpics: one of the provided Epics "${epic.name || '<anonymous>'}" does not return a stream. Double check you\'re not missing a return statement!`);
       }
-      return output$.pipe(
-        catchError(error => {
-          console.error(
-            epic.name,
-            error.constructor.name === 'ErrorEvent'
-            ? error.error.stack
-            : error
+      return (
+        output$.pipe
+          ? output$.pipe(
+            catchError(error => {
+              console.error(
+                epic.name,
+                error.constructor.name === 'ErrorEvent'
+                  ? error.error.stack
+                  : error
+              );
+
+              throw error;
+            })
           )
-          
-          throw error;
-        })
+          : output$
       );
     })
   );

--- a/test/combineEpics-spec.js
+++ b/test/combineEpics-spec.js
@@ -72,7 +72,7 @@ describe('combineEpics', () => {
     }).to.throw('combineEpics: one of the provided Epics "epic2" does not return a stream. Double check you\'re not missing a return statement!');
   });
 
-  it('should log the epic name when an error occurs', () => {
+  it('should log the epic name when an error occurs', done => {
     const epic1 = (actions, store) =>
       actions.pipe(
         ofType('ACTION1'),
@@ -92,23 +92,19 @@ describe('combineEpics', () => {
     const subject = new Subject();
     const actions = new ActionsObservable(subject);
 
-    rootEpic(actions).subscribe();
+    rootEpic(actions).subscribe({
+      error: console.error,
+    });
 
     const originalConsoleError = console.error;
 
-    console.error = (epicName, errorStack, ...rest) => {
+    console.error = (epicName, error) => {
       expect(epicName).to.equal('epic1');
-      expect(errorStack).to.include('Error: ERROR1');
+      expect(error).to.be.an('error');
+      done();
     };
 
     subject.next({ type: 'ACTION1' });
-
-    console.error = (epicName, errorStack, ...rest) => {
-      expect(epicName).to.equal('epic1');
-      expect(errorStack).to.include('Error: ERROR1');
-    };
-
-    subject.next({ type: 'ACTION2' });
 
     console.error = originalConsoleError;
   });

--- a/test/combineEpics-spec.js
+++ b/test/combineEpics-spec.js
@@ -18,7 +18,7 @@ describe('combineEpics', () => {
         map(action => ({ type: 'DELEGATED2', action, store }))
       );
 
-    const epic = combineEpics(
+    const rootEpic = combineEpics(
       epic1,
       epic2
     );
@@ -26,7 +26,7 @@ describe('combineEpics', () => {
     const store = { I: 'am', a: 'store' };
     const subject = new Subject();
     const actions = new ActionsObservable(subject);
-    const result = epic(actions, store);
+    const result = rootEpic(actions, store);
     const emittedActions = [];
 
     result.subscribe(emittedAction => emittedActions.push(emittedAction));


### PR DESCRIPTION
<!-- If this is your first PR for redux-observable, please mark these boxes to confirm (otherwise you can exclude them)-->

- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.

## Reason for PR

I noticed `combineEpics` doesn't do anything to help locate errors. Almost always, when using redux-observable, it's nearly impossible to find errors unless you've got a `catchError` at the bottom of your pipeline.

In my own Redux-less implementation of Redux-Observable, I added this functionality:

| `createRootEpic`  |  `catchEpicError` |
|:---:|:---:|
| ![createRootEpic](https://user-images.githubusercontent.com/3948069/66693572-fce67f00-ec6f-11e9-853c-37dede4ac338.png) | ![catchEpicError](https://user-images.githubusercontent.com/3948069/66693578-007a0600-ec70-11e9-88d2-ce50d87f32c3.png) |

Not only does this implementation include a way of logging errors as actions, it also logs them to the console with the name of the Epic that caused the error.

It's super helpful in debugging. `combineEpics` could definitely benefit from functionality like this.

In case there's a stack available such as the error being an `EventError` (Node.js), one of my other versions of this operator checks for stack information.

![image](https://user-images.githubusercontent.com/3948069/66693592-37e8b280-ec70-11e9-8e70-fb23ef0bc0b9.png)

## Changes
This method makes it obvious which epic actually threw an error and then throws it again so it proceeds as usual similar to doing a `Promise.prototype.catch` and throwing the error again so the next `.catch` picks it up.

Just like when throwing a `TypeError`, this also utilizes `epic.name`.
