### PR TITLE
Update AddingNewEpicsAsynchronously.md

### DIFF
--- a/docs/recipes/AddingNewEpicsAsynchronously.md
+++ b/docs/recipes/AddingNewEpicsAsynchronously.md
@@ -19,4 +19,4 @@ epic$.next(asyncEpic2);
 
 Keep in mind that any existing Epics will be left running as-is. This is not for actual replacement of Epics, like hot reloading.
 
-Adding new Epics to your root Epic is very safe, but replacing Epics that were already running with a new version can potentially create strange bugs because Epics naturally _may_ maintain state or depend on some external transient state or side effect. To learn more about that, check out the [`replaceEpic(nextEpic)`](HotModuleReplacement.md) method.
+Adding new Epics to your root Epic is very safe, but replacing Epics that were already running with a new version can potentially create strange bugs because Epics naturally _may_ maintain state or depend on some external transient state or side effect. To learn more about that, check out how to use [`BehaviorSubject`](HotModuleReplacement.md) instance to subscribe to an epic, which you can terminate and replace with another one asynchronously.


### PR DESCRIPTION
Suggesting to remove info about `replaceEpic`, as this one has been removed in 1.0.0-alpha.3. So description is not confusing, and in order to force using BehaviorSubject

<!-- If this is your first PR for redux-observable, please mark these boxes to confirm (otherwise you can exclude them)-->

- [ ] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [ ] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.
