### PR TITLE
Change state type param default to any

### DIFF
--- a/src/createEpicMiddleware.ts
+++ b/src/createEpicMiddleware.ts
@@ -1,9 +1,9 @@
-import { Action as ReduxAction, Dispatch, Middleware, MiddlewareAPI } from 'redux';
-import { from, Subject, queueScheduler } from 'rxjs';
-import { map, mergeMap, observeOn, subscribeOn } from 'rxjs/operators';
-import { Epic } from './epic';
-import { StateObservable } from './StateObservable';
-import { warn } from './utils/console';
+import { Action as ReduxAction, Dispatch, Middleware, MiddlewareAPI } from "redux";
+import { from, Subject, queueScheduler } from "rxjs";
+import { map, mergeMap, observeOn, subscribeOn } from "rxjs/operators";
+import { Epic } from "./epic";
+import { StateObservable } from "./StateObservable";
+import { warn } from "./utils/console";
 
 interface Options<Dependencies = any> {
   dependencies?: Dependencies;
@@ -24,80 +24,70 @@ export function createEpicMiddleware<
   State = any,
   Dependencies = any
 >(options: Options<Dependencies> = {}): EpicMiddleware<Action, Output, State, Dependencies> {
-  // This isn't a great solution, however RxJS does not **publicly** export the constructor for
+  // This isn"t a great solution, however RxJS does not **publicly** export the constructor for
   // QueueScheduler nor QueueAction, so we reach in. We need to do this because
-  // we don't want our internal queuing mechanism to be on the same queue as any
+  // we don"t want our internal queuing mechanism to be on the same queue as any
   // other RxJS code outside of redux-observable internals.
   // See this discussion:
   // https://github.com/redux-observable/redux-observable/pull/734#discussion_r459519441_
-  const {
-    SchedulerAction,
-    constructor: QueueScheduler,
-  } = queueScheduler as any;
+  const { SchedulerAction, constructor: QueueScheduler } = queueScheduler as any;
 
-  const uniqueQueueScheduler: typeof queueScheduler = new QueueScheduler(
-    SchedulerAction
-  );
+  const uniqueQueueScheduler: typeof queueScheduler = new QueueScheduler(SchedulerAction);
 
-  if (process.env.NODE_ENV !== 'production' && typeof options === 'function') {
+  if (process.env.NODE_ENV !== "production" && typeof options === "function") {
     throw new TypeError(
-      'Providing your root Epic to `createEpicMiddleware(rootEpic)` is no longer supported, instead use `epicMiddleware.run(rootEpic)`\n\nLearn more: https://redux-observable.js.org/MIGRATION.html#setting-up-the-middleware'
+      "Providing your root Epic to `createEpicMiddleware(rootEpic)` is no longer supported, instead use `epicMiddleware.run(rootEpic)`\n\nLearn more: https://redux-observable.js.org/MIGRATION.html#setting-up-the-middleware"
     );
   }
 
   const epic$ = new Subject<Epic<Action, Output, State, Dependencies>>();
   let store: MiddlewareAPI<Dispatch<any>, State>;
 
-  const epicMiddleware: EpicMiddleware<Action, Output, State, Dependencies> = (_store) => {
-    if (process.env.NODE_ENV !== 'production' && store) {
+  const epicMiddleware: EpicMiddleware<Action, Output, State, Dependencies> = _store => {
+    if (process.env.NODE_ENV !== "production" && store) {
       // https://github.com/redux-observable/redux-observable/issues/389
       warn(
-        'this middleware is already associated with a store. createEpicMiddleware should be called for every store.\n\nLearn more: https://goo.gl/2GQ7Da'
+        "this middleware is already associated with a store. createEpicMiddleware should be called for every store.\n\nLearn more: https://goo.gl/2GQ7Da"
       );
     }
     store = _store;
     const actionSubject$ = new Subject<Action>();
     const stateSubject$ = new Subject<State>();
-    const action$ = actionSubject$
-      .asObservable()
-      .pipe(observeOn(uniqueQueueScheduler));
+    const action$ = actionSubject$.asObservable().pipe(observeOn(uniqueQueueScheduler));
     const state$ = new StateObservable(
       stateSubject$.pipe(observeOn(uniqueQueueScheduler)),
       store.getState()
     );
 
     const result$ = epic$.pipe(
-      map((epic) => {
+      map(epic => {
         const output$ = epic(action$, state$, options.dependencies!);
 
         if (!output$) {
           throw new TypeError(
             `Your root Epic "${
-              epic.name || '<anonymous>'
-            }" does not return a stream. Double check you\'re not missing a return statement!`
+            epic.name || "<anonymous>"
+            }" does not return a stream. Double check you\"re not missing a return statement!`
           );
         }
 
         return output$;
       }),
-      mergeMap((output$) =>
-        from(output$).pipe(
-          subscribeOn(uniqueQueueScheduler),
-          observeOn(uniqueQueueScheduler)
-        )
+      mergeMap(output$ =>
+        from(output$).pipe(subscribeOn(uniqueQueueScheduler), observeOn(uniqueQueueScheduler))
       )
     );
 
     result$.subscribe(store.dispatch);
 
-    return (next) => {
-      return (action) => {
+    return next => {
+      return action => {
         // Downstream middleware gets the action first,
         // which includes their reducers, so state is
         // updated before epics receive the action
         const result = next(action);
 
-        // It's important to update the state$ before we emit
+        // It"s important to update the state$ before we emit
         // the action because otherwise it would be stale
         stateSubject$.next(store.getState());
         actionSubject$.next(action);
@@ -107,10 +97,10 @@ export function createEpicMiddleware<
     };
   };
 
-  epicMiddleware.run = (rootEpic) => {
-    if (process.env.NODE_ENV !== 'production' && !store) {
+  epicMiddleware.run = rootEpic => {
+    if (process.env.NODE_ENV !== "production" && !store) {
       warn(
-        'epicMiddleware.run(rootEpic) called before the middleware has been setup by redux. Provide the epicMiddleware instance to createStore() first.'
+        "epicMiddleware.run(rootEpic) called before the middleware has been setup by redux. Provide the epicMiddleware instance to createStore() first."
       );
     }
     epic$.next(rootEpic);

--- a/src/createEpicMiddleware.ts
+++ b/src/createEpicMiddleware.ts
@@ -24,9 +24,9 @@ export function createEpicMiddleware<
   State = any,
   Dependencies = any
 >(options: Options<Dependencies> = {}): EpicMiddleware<Action, Output, State, Dependencies> {
-  // This isn"t a great solution, however RxJS does not **publicly** export the constructor for
+  // This isn't a great solution, however RxJS does not **publicly** export the constructor for
   // QueueScheduler nor QueueAction, so we reach in. We need to do this because
-  // we don"t want our internal queuing mechanism to be on the same queue as any
+  // we don't want our internal queuing mechanism to be on the same queue as any
   // other RxJS code outside of redux-observable internals.
   // See this discussion:
   // https://github.com/redux-observable/redux-observable/pull/734#discussion_r459519441_
@@ -67,7 +67,7 @@ export function createEpicMiddleware<
           throw new TypeError(
             `Your root Epic "${
             epic.name || "<anonymous>"
-            }" does not return a stream. Double check you\"re not missing a return statement!`
+            }" does not return a stream. Double check you're not missing a return statement!`
           );
         }
 

--- a/src/createEpicMiddleware.ts
+++ b/src/createEpicMiddleware.ts
@@ -12,7 +12,7 @@ interface Options<D = any> {
 export interface EpicMiddleware<
   T extends Action,
   O extends T = T,
-  S = void,
+  S = any,
   D = any
 > extends Middleware<{}, S, Dispatch<any>> {
   run(rootEpic: Epic<T, O, S, D>): void;
@@ -21,7 +21,7 @@ export interface EpicMiddleware<
 export function createEpicMiddleware<
   T extends Action,
   O extends T = T,
-  S = void,
+  S = any,
   D = any
 >(options: Options<D> = {}): EpicMiddleware<T, O, S, D> {
   // This isn't great. RxJS doesn't publicly export the constructor for


### PR DESCRIPTION
The following changes were made:
* The type names have been changed to be semantic.
* `State` defaults to `any`.
* The deleterious method of grabbing `RxJS`'s `queueScheduler` constructor and action has been removed and replaced with a legitimate imports from `RxJS` internals.

<!-- If this is your first PR for redux-observable, please mark these boxes to confirm (otherwise you can exclude them)-->

- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.