### PR TITLE
fix(package.json): avoid tslib version issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "peerDependencies": {
     "redux": ">=4 <5",
     "rxjs": ">=6.0.0-beta.0 <7",
-    "tslib": "^1.9.0"
+    "tslib": "^1.9.0 || >=2.0.0 <3"
   },
   "devDependencies": {
     "@types/chai": "^3.5.2",


### PR DESCRIPTION
This PR fixes issues with NPM peer-dependency installation when the host project uses `tslib` >2.0.0.

![image](https://user-images.githubusercontent.com/8770194/111381292-ce12da80-86a5-11eb-8def-53598c3b110d.png)

Closes #740