### PR TITLE
fix(dependencies): rxjs and tslib are now listed as dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,10 @@
     "": {
       "version": "2.0.0-rc.1",
       "license": "MIT",
+      "dependencies": {
+        "rxjs": "^7.0.0",
+        "tslib": "~2.1.0"
+      },
       "devDependencies": {
         "@types/chai": "^3.5.2",
         "@types/mocha": "^2.2.48",
@@ -42,9 +46,7 @@
         "webpack-rxjs-externals": "~2.0.0"
       },
       "peerDependencies": {
-        "redux": ">=4 <5",
-        "rxjs": "^7.0.0",
-        "tslib": "~2.1.0"
+        "redux": ">=4 <5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -15691,7 +15693,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.0.0.tgz",
       "integrity": "sha512-I1V/ArAtGJg4kmCfms8fULm0SwYgEsAf2d5WPCBGzTYm2qTjO3Tx4EDFaGjbOox8CeEsC69jQK22mnmfyA26sw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "~2.1.0"
@@ -16774,8 +16775,7 @@
     "node_modules/tslib": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-      "dev": true
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -31331,7 +31331,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.0.0.tgz",
       "integrity": "sha512-I1V/ArAtGJg4kmCfms8fULm0SwYgEsAf2d5WPCBGzTYm2qTjO3Tx4EDFaGjbOox8CeEsC69jQK22mnmfyA26sw==",
-      "dev": true,
       "requires": {
         "tslib": "~2.1.0"
       }
@@ -32252,8 +32251,7 @@
     "tslib": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-      "dev": true
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,9 @@
   },
   "homepage": "https://github.com/redux-observable/redux-observable#README.md",
   "peerDependencies": {
-    "redux": ">=4 <5",
+    "redux": ">=4 <5"
+  },
+  "dependencies": {
     "rxjs": "^7.0.0",
     "tslib": "~2.1.0"
   },


### PR DESCRIPTION
We directly import from these libraries, so they should be in dependencies. This should prevent issues with plug'n'play in Yarn2. Redux is only used for type imports so it can stay in peerDependencies.

In #740 I said we could disable tslib, I'm not sure how I reached that conclusion because it's being used for StateObservable.

closes https://github.com/redux-observable/redux-observable/issues/740
