### PR TITLE
fix(documentation): Update `Adding New Epics Asynchronously/Lazily`

### DIFF
--- a/docs/recipes/AddingNewEpicsAsynchronously.md
+++ b/docs/recipes/AddingNewEpicsAsynchronously.md
@@ -6,6 +6,8 @@ If you are doing code splitting or otherwise want to add an Epic to the middlewa
 import { BehaviorSubject } from 'rxjs';
 import { combineEpics } from 'redux-observable';
 
+// In case your dynamic epics might register before adding the rootEpic to the middleware, aka before the initial subscribe,
+// you might want to use ReplaySubject instead, otherwise epic1 and epic2 will not register
 const epic$ = new BehaviorSubject(combineEpics(epic1, epic2));
 const rootEpic = (action$, state$) => epic$.pipe(
   mergeMap(epic => epic(action$, state$))


### PR DESCRIPTION
fix(documentation): Update `Adding New Epics Asynchronously/Lazily`

Add tip in comment how to support dynamic epics that register immediately

<!-- If this is your first PR for redux-observable, please mark these boxes to confirm (otherwise you can exclude them)-->

- [X] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [X] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.
