### PR TITLE
update docs for use with `configureStore` and show usage with Redux Toolkit

### DIFF
--- a/docs/api/createEpicMiddleware.md
+++ b/docs/api/createEpicMiddleware.md
@@ -16,20 +16,20 @@
 ### redux/configureStore.js
 
 ```js
-import { createStore, applyMiddleware, compose } from 'redux';
+import { configureStore } from '@reduxjs/toolkit';
 import { createEpicMiddleware } from 'redux-observable';
-import { rootEpic, rootReducer } from './modules/root';
+import { rootEpic } from './modules/rootEpic';
 
 const epicMiddleware = createEpicMiddleware();
 
-export default function configureStore() {
-  const store = createStore(
-    rootReducer,
-    applyMiddleware(epicMiddleware)
-  );
+export const store = configureStore({
+  reducer: {
+    // ...reducers...
+  },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(epicMiddleware),
+});
 
   epicMiddleware.run(rootEpic);
-
-  return store;
 }
 ```

--- a/docs/recipes/HotModuleReplacement.md
+++ b/docs/recipes/HotModuleReplacement.md
@@ -12,7 +12,13 @@ import { BehaviorSubject } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 
 const epicMiddleware = createEpicMiddleware();
-const store = createStore(rootReducer, applyMiddleware(epicMiddleware));
+const store = configureStore({
+  reducer: {
+    // ... reducers ...
+  },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(epicMiddleware),
+});
 
 const epic$ = new BehaviorSubject(rootEpic);
 // Every time a new epic is given to epic$ it
@@ -43,7 +49,13 @@ import { BehaviorSubject } from 'rxjs';
 import { mergeMap, takeUntil } from 'rxjs/operators';
 
 const epicMiddleware = createEpicMiddleware();
-const store = createStore(rootReducer, applyMiddleware(epicMiddleware));
+const store = configureStore({
+  reducer: {
+    // ... reducers ...
+  },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(epicMiddleware),
+});
 
 const epic$ = new BehaviorSubject(rootEpic);
 // Since we're using mergeMap, by default any new


### PR DESCRIPTION
Since `createStore` is now officially deprecated in favor to `configureStore` and we are trying to get more people to onboard to RTK, I though I'd make a docs PR in the spirit of #706 .

…
<!-- If this is your first PR for redux-observable, please mark these boxes to confirm (otherwise you can exclude them)-->

- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.
