### PR TITLE
fix: remove `extends Action` from Epic generic argument

### DIFF
--- a/src/epic.ts
+++ b/src/epic.ts
@@ -1,9 +1,8 @@
-import { Action } from 'redux';
 import { Observable } from 'rxjs';
 import { StateObservable } from './StateObservable';
 
 export declare interface Epic<
-  Input extends Action = any,
+  Input = any,
   Output extends Input = Input,
   State = any,
   Dependencies = any


### PR DESCRIPTION
Fixes https://github.com/redux-observable/redux-observable/issues/605

- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.
