### PR TITLE
Remove POJO abbreviation in basic docs

### DIFF
--- a/docs/basics/Epics.md
+++ b/docs/basics/Epics.md
@@ -149,7 +149,7 @@ const fetchUserEpic = action$ => action$.pipe(
 dispatch(fetchUser('torvalds'));
 ```
 
-> We're using action creators (aka factories) like `fetchUser` instead of creating the action POJO directly. This is a Redux convention that is totally optional.
+> We're using action creators (aka factories) like `fetchUser` instead of creating a plain action object directly. This is a Redux convention that is totally optional.
 
 We have a standard Redux action creator `fetchUser`, but also a corresponding Epic to orchestrate the actual AJAX call. When that AJAX call comes back, we map the response to a `FETCH_USER_FULFILLED` action.
 


### PR DESCRIPTION
Abbreviations hide meaning and introduce friction in reading. They add no value.

This change expands "action POJO" into "plain action object".

<!-- If this is your first PR for redux-observable, please mark these boxes to confirm (otherwise you can exclude them)-->

- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.
